### PR TITLE
Fix typo in GolangCI-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-linters-setting:
+linters-settings:
   depguard:
     list-type: blacklist
     include-go-root: false
@@ -96,5 +96,6 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - gomnd


### PR DESCRIPTION
`linters-setting` --> `linters-settings`