### PR TITLE
[xtime] TimeMilli and TimestampMilli structures with millisecond-precision encoding/decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.40
+          version: v1.41
   # tests
   go-test:
     needs: golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,3 +99,4 @@ issues:
         - dupl
         - funlen
         - gomnd
+        - ifshort

--- a/xtime/format.go
+++ b/xtime/format.go
@@ -1,0 +1,6 @@
+package xtime
+
+// These are predefined extra layouts for use in Time.Format and time.Parse.
+const (
+	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
+)

--- a/xtime/format_test.go
+++ b/xtime/format_test.go
@@ -1,0 +1,42 @@
+package xtime_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/jlourenc/xgo/xtime"
+)
+
+func TestLayouts(t *testing.T) {
+	x := time.Date(2016, 7, 10, 21, 12, 0, 499999999, time.UTC)
+
+	testCases := []struct {
+		name   string
+		layout string
+		value  string
+		offset time.Duration
+	}{
+		{
+			name:   "RFC3339Milli",
+			layout: RFC3339Milli,
+			value:  "2016-07-10T21:12:00.499Z",
+			offset: 999999 * time.Nanosecond,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fmt := x.Format(tc.layout)
+			if fmt != tc.value {
+				t.Errorf("expected %s; got %s", tc.value, fmt)
+			}
+
+			p, err := time.Parse(tc.layout, tc.value)
+			if err != nil {
+				t.Errorf("no error expected; got %s", err)
+			} else if p.Add(tc.offset) != x {
+				t.Errorf("expected %v; got %v", x, p.Add(tc.offset))
+			}
+		})
+	}
+}

--- a/xtime/time.go
+++ b/xtime/time.go
@@ -1,0 +1,219 @@
+package xtime
+
+import (
+	"errors"
+	"strconv"
+	"time"
+)
+
+const (
+	hourInDay  = 24
+	minInHour  = 60
+	msecInSec  = 1e3
+	nsecInMsec = 1e6
+	secInMin   = 60
+)
+
+// A TimeMilli represents an instant in time with nanosecond precision,
+// except for JSON/Text encoding/decoding which is of millisecond precision:
+// - encoding uses xtime.RFC3339Milli layout,
+// - decoding handles both Unix timestamps in milliseconds and xtime.RFC3339Milli layout.
+//
+// See time.Time for more information.
+type TimeMilli struct {
+	time.Time
+}
+
+// DateMilli returns the Time corresponding to
+//	yyyy-mm-dd hh:mm:ss + msec milliseconds
+// in the appropriate zone for that time in the given location.
+//
+// See time.Date for more information.
+func DateMilli(year int, month time.Month, day, hour, min, sec, msec int, loc *time.Location) TimeMilli {
+	// Normalize msec, sec, min, hour, overflowing into day.
+	sec, msec = norm(sec, msec, msecInSec)
+	min, sec = norm(min, sec, secInMin)
+	hour, min = norm(hour, min, minInHour)
+	day, hour = norm(day, hour, hourInDay)
+
+	return TimeMilli{time.Date(year, month, day, hour, min, sec, msec*nsecInMsec, loc)}
+}
+
+// NowMilli returns the current local time.
+//
+// See time.Now for more information.
+func NowMilli() TimeMilli {
+	return TimeMilli{time.Now()}
+}
+
+// ToMilli is a convenience function to convert a time.Time into TimeMilli.
+func ToMilli(t time.Time) TimeMilli {
+	return TimeMilli{t}
+}
+
+// UnixMilli returns the local TimeMilli corresponding to the given Unix time,
+// sec seconds and msec milliseconds since January 1, 1970 UTC.
+// It is valid to pass msec outside the range [0, 999].
+//
+// See time.Unix for more information.
+func UnixMilli(sec, msec int64) TimeMilli {
+	if msec < 0 || msec >= msecInSec {
+		n := msec / msecInSec
+		sec += n
+		msec -= n * msecInSec
+		if msec < 0 {
+			msec += msecInSec
+			sec--
+		}
+	}
+	return TimeMilli{time.Unix(sec, msec*nsecInMsec)}
+}
+
+// Add returns the time t+d.
+//
+// See time.Time.Add for more information.
+func (t TimeMilli) Add(d time.Duration) TimeMilli {
+	return TimeMilli{t.Time.Add(d)}
+}
+
+// AddDate returns the time corresponding to adding the
+// given number of years, months, and days to t.
+//
+// See time.Time.AddDate for more information.
+func (t TimeMilli) AddDate(years, months, days int) TimeMilli {
+	return TimeMilli{t.Time.AddDate(years, months, days)}
+}
+
+// In returns a copy of t representing the same timestamp instant, but
+// with the copy's location information set to loc for display
+// purposes.
+//
+// See time.Time.In for more information.
+func (t TimeMilli) In(loc *time.Location) TimeMilli {
+	return TimeMilli{t.Time.In(loc)}
+}
+
+// Local returns t with the location set to local time.
+//
+// See time.Time.Local for more information.
+func (t TimeMilli) Local() TimeMilli {
+	return TimeMilli{t.Time.Local()}
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// The time is a quoted string in RFC 3339 format, with sub-second precision added if present.
+func (t TimeMilli) MarshalJSON() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		// RFC 3339 is clear that years are 4 digits exactly.
+		// See golang.org/issue/4556#c15 for more discussion.
+		return nil, errors.New("TimeMilli.MarshalJSON: year outside of range [0,9999]")
+	}
+
+	b := make([]byte, 0, len(RFC3339Milli)+2) //nolint:gomnd // Extra 2 double quotes.
+	b = append(b, '"')
+	b = t.AppendFormat(b, RFC3339Milli)
+	b = append(b, '"')
+	return b, nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The time is formatted in RFC 3339 format, with sub-second precision added if present.
+func (t TimeMilli) MarshalText() ([]byte, error) {
+	if y := t.Year(); y < 0 || y >= 10000 {
+		return nil, errors.New("TimeMilli.MarshalText: year outside of range [0,9999]")
+	}
+
+	b := make([]byte, 0, len(RFC3339Milli))
+	return t.AppendFormat(b, RFC3339Milli), nil
+}
+
+// Millisecond returns the millisecond offset within the second specified by t,
+// in the range [0, 999].
+func (t TimeMilli) Millisecond() int {
+	return t.Nanosecond() / nsecInMsec
+}
+
+// Round returns the result of rounding t to the nearest multiple of d (since the zero time).
+//
+// See time.Time.Round for more information.
+func (t TimeMilli) Round(d time.Duration) TimeMilli {
+	return TimeMilli{t.Time.Round(d)}
+}
+
+// T is a convenience method to access the underlying time.Time structure
+// for compatibility with the Go standard time package.
+func (t TimeMilli) T() time.Time {
+	return t.Time
+}
+
+// Truncate returns the result of rounding t down to a multiple of d (since the zero time).
+//
+// See time.Time.Truncate for more information.
+func (t TimeMilli) Truncate(d time.Duration) TimeMilli {
+	return TimeMilli{t.Time.Truncate(d)}
+}
+
+// UTC returns t with the location set to UTC.
+//
+// See time.Time.UTC for more information.
+func (t TimeMilli) UTC() TimeMilli {
+	return TimeMilli{t.Time.UTC()}
+}
+
+// UnixMilli returns t as a Unix timestamp, the number of milliseconds elapsed
+// since Time 1, 1970 UTC. The result does not depend on the location associated with it.
+func (t TimeMilli) UnixMilli() int64 {
+	return t.UnixNano() / nsecInMsec
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// The time is expected to be:
+// - either a quoted string in RFC 3339 format,
+// - or a timestamp with millisecond precision expressed either as a number or a quoted string.
+//
+// See time.Time.UnmarshalJSON for more information.
+func (t *TimeMilli) UnmarshalJSON(data []byte) error {
+	b, e := 0, len(data)-1
+	if len(data) > 1 && data[b] == '"' && data[e] == '"' {
+		b++
+		e--
+	}
+
+	if i, err := strconv.ParseInt(string(data[b:e+1]), 10, 64); err == nil { //nolint:gomnd // Decimal (base-10) integer.
+		*t = UnixMilli(0, i)
+		return nil
+	}
+
+	return t.Time.UnmarshalJSON(data)
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// The time is expected to be:
+// - either a timestamp with millisecond precision,
+// - or in RFC 3339 format.
+//
+// See time.Time.UnmarshalText for more information.
+func (t *TimeMilli) UnmarshalText(data []byte) error {
+	if i, err := strconv.ParseInt(string(data), 10, 64); err == nil { //nolint:gomnd // Decimal (base-10) integer.
+		*t = UnixMilli(0, i)
+		return nil
+	}
+	return t.Time.UnmarshalText(data)
+}
+
+// norm returns nhi, nlo such that
+//	hi * base + lo == nhi * base + nlo
+//	0 <= nlo < base
+func norm(hi, lo, base int) (nhi, nlo int) {
+	if lo < 0 {
+		n := (-lo-1)/base + 1
+		hi -= n
+		lo += n * base
+	}
+	if lo >= base {
+		n := lo / base
+		hi += n
+		lo -= n * base
+	}
+	return hi, lo
+}

--- a/xtime/time_test.go
+++ b/xtime/time_test.go
@@ -1,0 +1,621 @@
+package xtime_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/jlourenc/xgo/xtime"
+)
+
+func TestDateMilli(t *testing.T) {
+	testCases := []struct {
+		name     string
+		year     int
+		month    time.Month
+		day      int
+		hour     int
+		min      int
+		sec      int
+		msec     int
+		loc      *time.Location
+		expected time.Time
+	}{
+		{
+			name:     "UTC - no overflow",
+			year:     2016,
+			month:    time.July,
+			day:      10,
+			hour:     21,
+			min:      12,
+			sec:      0,
+			msec:     499,
+			loc:      time.UTC,
+			expected: time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.UTC),
+		},
+		{
+			name:     "Local - no overflow",
+			year:     2016,
+			month:    time.July,
+			day:      10,
+			hour:     21,
+			min:      12,
+			sec:      0,
+			msec:     499,
+			loc:      time.Local,
+			expected: time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.Local),
+		},
+		{
+			name:     "UTC - positive overflow",
+			year:     2016,
+			month:    time.December,
+			day:      31,
+			hour:     23,
+			min:      59,
+			sec:      59,
+			msec:     1499,
+			loc:      time.UTC,
+			expected: time.Date(2017, time.January, 1, 0, 0, 0, 499000000, time.UTC),
+		},
+		{
+			name:     "UTC - negative overflow",
+			year:     2016,
+			month:    time.July,
+			day:      10,
+			hour:     21,
+			min:      12,
+			sec:      0,
+			msec:     -1,
+			loc:      time.UTC,
+			expected: time.Date(2016, time.July, 10, 21, 11, 59, 999000000, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DateMilli(tc.year, tc.month, tc.day, tc.hour, tc.min, tc.sec, tc.msec, tc.loc)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestNowMilli(t *testing.T) {
+	before := time.Now()
+	time.Sleep(time.Millisecond)
+	got := NowMilli()
+	time.Sleep(time.Millisecond)
+	after := time.Now()
+
+	if !got.After(before) || !after.After(got.T()) {
+		t.Errorf("%s expected to be in range [%s, %s]", got, before, after)
+	}
+}
+
+func TestToMilli(t *testing.T) {
+	expected := time.Now()
+	got := ToMilli(expected)
+
+	if !got.Equal(expected) {
+		t.Errorf("expected %s; got %s", expected, got)
+	}
+}
+
+func TestUnixMilli(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sec      int64
+		msec     int64
+		expected time.Time
+	}{
+		{
+			name:     "within msec range",
+			sec:      1468181520,
+			msec:     499,
+			expected: time.Unix(1468181520, 499000000),
+		},
+		{
+			name:     "outside msec range - positive",
+			sec:      1468181520,
+			msec:     61499,
+			expected: time.Unix(1468181581, 499000000),
+		},
+		{
+			name:     "outside msec range - negative",
+			sec:      1468181520,
+			msec:     -1,
+			expected: time.Unix(1468181519, 999000000),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UnixMilli(tc.sec, tc.msec)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_Add(t *testing.T) {
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		duration time.Duration
+		expected TimeMilli
+	}{
+		{
+			name:     "zero duration",
+			time:     UnixMilli(1468181520, 499),
+			duration: 0,
+			expected: UnixMilli(1468181520, 499),
+		},
+		{
+			name:     "positive duration",
+			time:     UnixMilli(1468181520, 499),
+			duration: 20 * time.Second,
+			expected: UnixMilli(1468181540, 499),
+		},
+		{
+			name:     "negative duration",
+			time:     UnixMilli(1468181520, 499),
+			duration: -20 * time.Second,
+			expected: UnixMilli(1468181500, 499),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.Add(tc.duration)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_AddDate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		years    int
+		months   int
+		days     int
+		expected TimeMilli
+	}{
+		{
+			name:     "zero values",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			years:    0,
+			months:   0,
+			days:     0,
+			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:     "no overflow values",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			years:    3,
+			months:   2,
+			days:     1,
+			expected: DateMilli(2019, time.September, 11, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:     "with overflow values",
+			time:     DateMilli(2016, time.December, 31, 21, 12, 0, 499, time.UTC),
+			years:    1,
+			months:   1,
+			days:     1,
+			expected: DateMilli(2018, time.February, 1, 21, 12, 0, 499, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.AddDate(tc.years, tc.months, tc.days)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_In(t *testing.T) {
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		location *time.Location
+		expected TimeMilli
+	}{
+		{
+			name:     "UTC to UTC",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			location: time.UTC,
+			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:     "UTC to CET",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			location: time.FixedZone("CET", 2*60*60),
+			expected: DateMilli(2016, time.July, 10, 23, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.In(tc.location)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_Local(t *testing.T) {
+	_, localOffset := time.Now().Local().Zone()
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		expected TimeMilli
+	}{
+		{
+			name:     "from UTC",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: DateMilli(2016, time.July, 10, 21, 12, localOffset, 499, time.Local),
+		},
+		{
+			name:     "from Local",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.Local()
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_MarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name          string
+		time          TimeMilli
+		expectedBytes []byte
+		expectedErr   error
+	}{
+		{
+			name:          "invalid year",
+			time:          DateMilli(10001, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedBytes: nil,
+			expectedErr:   errors.New("TimeMilli.MarshalJSON: year outside of range [0,9999]"),
+		},
+		{
+			name:          "UTC - with msec",
+			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedBytes: []byte(`"2016-07-10T21:12:00.499Z"`),
+			expectedErr:   nil,
+		},
+		{
+			name:          "zone info - no msec",
+			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedBytes: []byte(`"2016-07-10T21:12:00+02:00"`),
+			expectedErr:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBytes, gotErr := tc.time.MarshalJSON()
+
+			if string(tc.expectedBytes) != string(gotBytes) {
+				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
+			}
+
+			if (tc.expectedErr == nil && gotErr != nil) ||
+				(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+				t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_MarshalText(t *testing.T) {
+	testCases := []struct {
+		name          string
+		time          TimeMilli
+		expectedBytes []byte
+		expectedErr   error
+	}{
+		{
+			name:          "invalid year",
+			time:          DateMilli(10001, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedBytes: nil,
+			expectedErr:   errors.New("TimeMilli.MarshalText: year outside of range [0,9999]"),
+		},
+		{
+			name:          "UTC - with msec",
+			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedBytes: []byte(`2016-07-10T21:12:00.499Z`),
+			expectedErr:   nil,
+		},
+		{
+			name:          "zone info - no msec",
+			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedBytes: []byte(`2016-07-10T21:12:00+02:00`),
+			expectedErr:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBytes, gotErr := tc.time.MarshalText()
+
+			if string(tc.expectedBytes) != string(gotBytes) {
+				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
+			}
+
+			if (tc.expectedErr == nil && gotErr != nil) ||
+				(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+				t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_Millisecond(t *testing.T) {
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		expected int
+	}{
+		{
+			name:     "no msec",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			expected: 0,
+		},
+		{
+			name:     "with msec",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: 499,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.Millisecond()
+			if tc.expected != got {
+				t.Errorf("expected %d; got %d", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_Round(t *testing.T) {
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		duration time.Duration
+		expected TimeMilli
+	}{
+		{
+			name:     "nearest second",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			duration: 2 * time.Second,
+			expected: DateMilli(2016, time.July, 10, 21, 12, 2, 0, time.UTC),
+		},
+		{
+			name:     "nearest hour",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			duration: time.Hour,
+			expected: DateMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.Round(tc.duration)
+			if tc.expected != got {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_T(t *testing.T) {
+	x := DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC)
+	expected := time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.UTC)
+	got := x.T()
+
+	if !expected.Equal(got) {
+		t.Errorf("expected %s; got %s", expected, got)
+	}
+}
+
+func TestTimeMilli_Truncate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		duration time.Duration
+		expected TimeMilli
+	}{
+		{
+			name:     "rounding down to a multiple of 2 seconds",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			duration: 2 * time.Second,
+			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+		},
+		{
+			name:     "rounding down to nearest hour",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			duration: time.Hour,
+			expected: DateMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.Truncate(tc.duration)
+			if tc.expected != got {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_UTC(t *testing.T) {
+	_, localOffset := time.Now().Local().Zone()
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		expected TimeMilli
+	}{
+		{
+			name:     "from UTC",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:     "from Local",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			expected: DateMilli(2016, time.July, 10, 21, 12, -localOffset, 499, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.UTC()
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_UnixMilli(t *testing.T) {
+	testCases := []struct {
+		name     string
+		time     TimeMilli
+		expected int64
+	}{
+		{
+			name:     "no msec",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			expected: 1468185120000,
+		},
+		{
+			name:     "with msec",
+			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: 1468185120499,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.time.UnixMilli()
+			if tc.expected != got {
+				t.Errorf("expected %d; got %d", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimeMilli_UnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name         string
+		data         []byte
+		expectedTime TimeMilli
+		expectedErr  error
+	}{
+		{
+			name:         "double-quoted string timestamp",
+			data:         []byte(`"1468185120499"`),
+			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedErr:  nil,
+		},
+		{
+			name:         "number timestamp",
+			data:         []byte(`1468185120499`),
+			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedErr:  nil,
+		},
+		{
+			name:         "RFC3339 string",
+			data:         []byte(`"2016-07-10T21:12:00+02:00"`),
+			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:         "RFC3339Milli string",
+			data:         []byte(`"2016-07-10T21:12:00.499+02:00"`),
+			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:         "RFC3339Nano string",
+			data:         []byte(`"2016-07-10T21:12:00.499+02:00"`),
+			expectedTime: ToMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+		},
+	}
+
+	for _, tc := range testCases {
+		var gotTime TimeMilli
+		gotErr := gotTime.UnmarshalJSON(tc.data)
+
+		if !tc.expectedTime.Equal(gotTime.T()) {
+			t.Errorf("expected time %s; got %s", tc.expectedTime, gotTime)
+		}
+
+		if (tc.expectedErr == nil && gotErr != nil) ||
+			(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+			t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+		}
+	}
+}
+
+func TestTimeMilli_UnmarshalText(t *testing.T) {
+	testCases := []struct {
+		name         string
+		data         []byte
+		expectedTime TimeMilli
+		expectedErr  error
+	}{
+		{
+			name:         "timestamp",
+			data:         []byte(`1468185120499`),
+			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedErr:  nil,
+		},
+		{
+			name:         "RFC3339",
+			data:         []byte(`2016-07-10T21:12:00+02:00`),
+			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:         "RFC3339Milli",
+			data:         []byte(`2016-07-10T21:12:00.499+02:00`),
+			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:         "RFC3339Nano",
+			data:         []byte(`2016-07-10T21:12:00.499+02:00`),
+			expectedTime: ToMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+		},
+	}
+
+	for _, tc := range testCases {
+		var gotTime TimeMilli
+		gotErr := gotTime.UnmarshalText(tc.data)
+
+		if !tc.expectedTime.Equal(gotTime.T()) {
+			t.Errorf("expected time %s; got %s", tc.expectedTime, gotTime)
+		}
+
+		if (tc.expectedErr == nil && gotErr != nil) ||
+			(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+			t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+		}
+	}
+}

--- a/xtime/timestamp.go
+++ b/xtime/timestamp.go
@@ -1,0 +1,178 @@
+package xtime
+
+import (
+	"strconv"
+	"time"
+)
+
+// A TimestampMilli represents an instant in time with nanosecond precision,
+// except for JSON/Text encoding/decoding which is of millisecond precision:
+// - encoding uses Unix timestamps in milliseconds,
+// - decoding handles both Unix timestamps in milliseconds and xtime.RFC3339Milli layout.
+//
+// See time.Time for more information.
+type TimestampMilli struct {
+	time.Time
+}
+
+// DateStampMilli returns the Time corresponding to
+//	yyyy-mm-dd hh:mm:ss + msec milliseconds
+// in the appropriate zone for that timestamp in the given location.
+//
+// See time.Date for more information.
+func DateStampMilli(year int, month time.Month, day, hour, min, sec, msec int, loc *time.Location) TimestampMilli {
+	// Normalize msec, sec, min, hour, overflowing into day.
+	sec, msec = norm(sec, msec, msecInSec)
+	min, sec = norm(min, sec, secInMin)
+	hour, min = norm(hour, min, minInHour)
+	day, hour = norm(day, hour, hourInDay)
+
+	return TimestampMilli{time.Date(year, month, day, hour, min, sec, msec*nsecInMsec, loc)}
+}
+
+// NowStampMilli returns the current local time.
+//
+// See time.Now for more information.
+func NowStampMilli() TimestampMilli {
+	return TimestampMilli{time.Now()}
+}
+
+// ToStampMilli is a convenience function to convert a time.Time into TimestampMilli.
+func ToStampMilli(t time.Time) TimestampMilli {
+	return TimestampMilli{Time: t}
+}
+
+// UnixStampMilli returns the local TimestampMilli corresponding to the given Unix time,
+// sec seconds and msec milliseconds since January 1, 1970 UTC.
+// It is valid to pass msec outside the range [0, 999].
+//
+// See time.Unix for more information.
+func UnixStampMilli(sec, msec int64) TimestampMilli {
+	if msec < 0 || msec >= msecInSec {
+		n := msec / msecInSec
+		sec += n
+		msec -= n * msecInSec
+		if msec < 0 {
+			msec += msecInSec
+			sec--
+		}
+	}
+	return TimestampMilli{time.Unix(sec, msec*nsecInMsec)}
+}
+
+// Add returns the time t+d.
+//
+// See time.Time.Add for more information.
+func (t TimestampMilli) Add(d time.Duration) TimestampMilli {
+	return TimestampMilli{t.Time.Add(d)}
+}
+
+// AddDate returns the time corresponding to adding the
+// given number of years, months, and days to t.
+//
+// See time.Time.AddDate for more information.
+func (t TimestampMilli) AddDate(years, months, days int) TimestampMilli {
+	return TimestampMilli{t.Time.AddDate(years, months, days)}
+}
+
+// In returns a copy of t representing the same timestamp instant, but
+// with the copy's location information set to loc for display
+// purposes.
+//
+// See time.Time.In for more information.
+func (t TimestampMilli) In(loc *time.Location) TimestampMilli {
+	return TimestampMilli{t.Time.In(loc)}
+}
+
+// Local returns t with the location set to local time.
+//
+// See time.Time.Local for more information.
+func (t TimestampMilli) Local() TimestampMilli {
+	return TimestampMilli{t.Time.Local()}
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// The timestamp is a Unix timestamp with millisecond precision.
+func (t TimestampMilli) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatInt(t.UnixMilli(), 10)), nil //nolint:gomnd // Decimal (base-10) integer.
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The timestamp is a Unix timestamp with millisecond precision.
+func (t TimestampMilli) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatInt(t.UnixMilli(), 10)), nil //nolint:gomnd // Decimal (base-10) integer.
+}
+
+// Millisecond returns the millisecond offset within the second specified by t,
+// in the range [0, 999].
+func (t TimestampMilli) Millisecond() int {
+	return t.Nanosecond() / nsecInMsec
+}
+
+// Round returns the result of rounding t to the nearest multiple of d (since the zero time).
+//
+// See time.Time.Round for more information.
+func (t TimestampMilli) Round(d time.Duration) TimestampMilli {
+	return TimestampMilli{t.Time.Round(d)}
+}
+
+// T is a convenience method to access the underlying time.Time structure
+// for compatibility with the Go standard time package.
+func (t TimestampMilli) T() time.Time {
+	return t.Time
+}
+
+// Truncate returns the result of rounding t down to a multiple of d (since the zero time).
+//
+// See time.Time.Truncate for more information.
+func (t TimestampMilli) Truncate(d time.Duration) TimestampMilli {
+	return TimestampMilli{t.Time.Truncate(d)}
+}
+
+// UTC returns t with the location set to UTC.
+//
+// See time.Time.UTC for more information.
+func (t TimestampMilli) UTC() TimestampMilli {
+	return TimestampMilli{t.Time.UTC()}
+}
+
+// UnixMilli returns t as a Unix timestamp, the number of milliseconds elapsed
+// since Time 1, 1970 UTC. The result does not depend on the location associated with it.
+func (t TimestampMilli) UnixMilli() int64 {
+	return t.UnixNano() / nsecInMsec
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// The time is expected to be:
+// - either a quoted string in RFC 3339 format,
+// - or a timestamp with millisecond precision expressed either as a number or a quoted string.
+//
+// See time.Time.UnmarshalJSON for more information.
+func (t *TimestampMilli) UnmarshalJSON(data []byte) error {
+	b, e := 0, len(data)-1
+	if len(data) > 1 && data[b] == '"' && data[e] == '"' {
+		b++
+		e--
+	}
+
+	if i, err := strconv.ParseInt(string(data[b:e+1]), 10, 64); err == nil { //nolint:gomnd // Decimal (base-10) integer.
+		*t = UnixStampMilli(0, i)
+		return nil
+	}
+
+	return t.Time.UnmarshalJSON(data)
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// The time is expected to be:
+// - either a timestamp with millisecond precision,
+// - or in RFC 3339 format.
+//
+// See time.Time.UnmarshalText for more information.
+func (t *TimestampMilli) UnmarshalText(data []byte) error {
+	if i, err := strconv.ParseInt(string(data), 10, 64); err == nil { //nolint:gomnd // Decimal (base-10) integer.
+		*t = UnixStampMilli(0, i)
+		return nil
+	}
+	return t.Time.UnmarshalText(data)
+}

--- a/xtime/timestamp_test.go
+++ b/xtime/timestamp_test.go
@@ -1,0 +1,608 @@
+package xtime_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/jlourenc/xgo/xtime"
+)
+
+func TestDateStampMilli(t *testing.T) {
+	testCases := []struct {
+		name     string
+		year     int
+		month    time.Month
+		day      int
+		hour     int
+		min      int
+		sec      int
+		msec     int
+		loc      *time.Location
+		expected time.Time
+	}{
+		{
+			name:     "UTC - no overflow",
+			year:     2016,
+			month:    time.July,
+			day:      10,
+			hour:     21,
+			min:      12,
+			sec:      0,
+			msec:     499,
+			loc:      time.UTC,
+			expected: time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.UTC),
+		},
+		{
+			name:     "Local - no overflow",
+			year:     2016,
+			month:    time.July,
+			day:      10,
+			hour:     21,
+			min:      12,
+			sec:      0,
+			msec:     499,
+			loc:      time.Local,
+			expected: time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.Local),
+		},
+		{
+			name:     "UTC - positive overflow",
+			year:     2016,
+			month:    time.December,
+			day:      31,
+			hour:     23,
+			min:      59,
+			sec:      59,
+			msec:     1499,
+			loc:      time.UTC,
+			expected: time.Date(2017, time.January, 1, 0, 0, 0, 499000000, time.UTC),
+		},
+		{
+			name:     "UTC - negative overflow",
+			year:     2016,
+			month:    time.July,
+			day:      10,
+			hour:     21,
+			min:      12,
+			sec:      0,
+			msec:     -1,
+			loc:      time.UTC,
+			expected: time.Date(2016, time.July, 10, 21, 11, 59, 999000000, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DateStampMilli(tc.year, tc.month, tc.day, tc.hour, tc.min, tc.sec, tc.msec, tc.loc)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestNowStampMilli(t *testing.T) {
+	before := time.Now()
+	time.Sleep(time.Millisecond)
+	got := NowStampMilli()
+	time.Sleep(time.Millisecond)
+	after := time.Now()
+
+	if !got.After(before) || !after.After(got.T()) {
+		t.Errorf("%s expected to be in range [%s, %s]", got, before, after)
+	}
+}
+
+func TestToStampMilli(t *testing.T) {
+	expected := time.Now()
+	got := ToStampMilli(expected)
+
+	if !got.Equal(expected) {
+		t.Errorf("expected %s; got %s", expected, got)
+	}
+}
+
+func TestUnixStampMilli(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sec      int64
+		msec     int64
+		expected time.Time
+	}{
+		{
+			name:     "within msec range",
+			sec:      1468181520,
+			msec:     499,
+			expected: time.Unix(1468181520, 499000000),
+		},
+		{
+			name:     "outside msec range - positive",
+			sec:      1468181520,
+			msec:     61499,
+			expected: time.Unix(1468181581, 499000000),
+		},
+		{
+			name:     "outside msec range - negative",
+			sec:      1468181520,
+			msec:     -1,
+			expected: time.Unix(1468181519, 999000000),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UnixStampMilli(tc.sec, tc.msec)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_Add(t *testing.T) {
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		duration  time.Duration
+		expected  TimestampMilli
+	}{
+		{
+			name:      "zero duration",
+			timestamp: UnixStampMilli(1468181520, 499),
+			duration:  0,
+			expected:  UnixStampMilli(1468181520, 499),
+		},
+		{
+			name:      "positive duration",
+			timestamp: UnixStampMilli(1468181520, 499),
+			duration:  20 * time.Second,
+			expected:  UnixStampMilli(1468181540, 499),
+		},
+		{
+			name:      "negative duration",
+			timestamp: UnixStampMilli(1468181520, 499),
+			duration:  -20 * time.Second,
+			expected:  UnixStampMilli(1468181500, 499),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.Add(tc.duration)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_AddDate(t *testing.T) {
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		years     int
+		months    int
+		days      int
+		expected  TimestampMilli
+	}{
+		{
+			name:      "zero values",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			years:     0,
+			months:    0,
+			days:      0,
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:      "no overflow values",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			years:     3,
+			months:    2,
+			days:      1,
+			expected:  DateStampMilli(2019, time.September, 11, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:      "with overflow values",
+			timestamp: DateStampMilli(2016, time.December, 31, 21, 12, 0, 499, time.UTC),
+			years:     1,
+			months:    1,
+			days:      1,
+			expected:  DateStampMilli(2018, time.February, 1, 21, 12, 0, 499, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.AddDate(tc.years, tc.months, tc.days)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_In(t *testing.T) {
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		location  *time.Location
+		expected  TimestampMilli
+	}{
+		{
+			name:      "UTC to UTC",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			location:  time.UTC,
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:      "UTC to CET",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			location:  time.FixedZone("CET", 2*60*60),
+			expected:  DateStampMilli(2016, time.July, 10, 23, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.In(tc.location)
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_Local(t *testing.T) {
+	_, localOffset := time.Now().Local().Zone()
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		expected  TimestampMilli
+	}{
+		{
+			name:      "from UTC",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, localOffset, 499, time.Local),
+		},
+		{
+			name:      "from Local",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.Local()
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_MarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name          string
+		timestamp     TimestampMilli
+		expectedBytes []byte
+		expectedErr   error
+	}{
+		{
+			name:          "UTC - with msec",
+			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedBytes: []byte(`1468185120499`),
+			expectedErr:   nil,
+		},
+		{
+			name:          "zone info - no msec",
+			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedBytes: []byte(`1468177920000`),
+			expectedErr:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBytes, gotErr := tc.timestamp.MarshalJSON()
+
+			if string(tc.expectedBytes) != string(gotBytes) {
+				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
+			}
+
+			if (tc.expectedErr == nil && gotErr != nil) ||
+				(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+				t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_MarshalText(t *testing.T) {
+	testCases := []struct {
+		name          string
+		timestamp     TimestampMilli
+		expectedBytes []byte
+		expectedErr   error
+	}{
+		{
+			name:          "UTC - with msec",
+			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedBytes: []byte(`1468185120499`),
+			expectedErr:   nil,
+		},
+		{
+			name:          "zone info - no msec",
+			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedBytes: []byte(`1468177920000`),
+			expectedErr:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBytes, gotErr := tc.timestamp.MarshalText()
+
+			if string(tc.expectedBytes) != string(gotBytes) {
+				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
+			}
+
+			if (tc.expectedErr == nil && gotErr != nil) ||
+				(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+				t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_Millisecond(t *testing.T) {
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		expected  int
+	}{
+		{
+			name:      "no msec",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			expected:  0,
+		},
+		{
+			name:      "with msec",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  499,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.Millisecond()
+			if tc.expected != got {
+				t.Errorf("expected %d; got %d", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_Round(t *testing.T) {
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		duration  time.Duration
+		expected  TimestampMilli
+	}{
+		{
+			name:      "nearest second",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			duration:  2 * time.Second,
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 2, 0, time.UTC),
+		},
+		{
+			name:      "nearest hour",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			duration:  time.Hour,
+			expected:  DateStampMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.Round(tc.duration)
+			if tc.expected != got {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_T(t *testing.T) {
+	x := DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC)
+	expected := time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.UTC)
+	got := x.T()
+
+	if !expected.Equal(got) {
+		t.Errorf("expected %s; got %s", expected, got)
+	}
+}
+
+func TestTimestampMilli_Truncate(t *testing.T) {
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		duration  time.Duration
+		expected  TimestampMilli
+	}{
+		{
+			name:      "rounding down to a multiple of 2 seconds",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			duration:  2 * time.Second,
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+		},
+		{
+			name:      "rounding down to nearest hour",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			duration:  time.Hour,
+			expected:  DateStampMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.Truncate(tc.duration)
+			if tc.expected != got {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_UTC(t *testing.T) {
+	_, localOffset := time.Now().Local().Zone()
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		expected  TimestampMilli
+	}{
+		{
+			name:      "from UTC",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+		},
+		{
+			name:      "from Local",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			expected:  DateStampMilli(2016, time.July, 10, 21, 12, -localOffset, 499, time.UTC),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.UTC()
+			if !tc.expected.Equal(got.T()) {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_UnixMilli(t *testing.T) {
+	testCases := []struct {
+		name      string
+		timestamp TimestampMilli
+		expected  int64
+	}{
+		{
+			name:      "no msec",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			expected:  1468185120000,
+		},
+		{
+			name:      "with msec",
+			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  1468185120499,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.timestamp.UnixMilli()
+			if tc.expected != got {
+				t.Errorf("expected %d; got %d", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampMilli_UnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name              string
+		data              []byte
+		expectedTimestamp TimestampMilli
+		expectedErr       error
+	}{
+		{
+			name:              "double-quoted string timestamp",
+			data:              []byte(`"1468185120499"`),
+			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedErr:       nil,
+		},
+		{
+			name:              "number timestamp",
+			data:              []byte(`1468185120499`),
+			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedErr:       nil,
+		},
+		{
+			name:              "RFC3339 string",
+			data:              []byte(`"2016-07-10T21:12:00+02:00"`),
+			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:              "RFC3339Milli string",
+			data:              []byte(`"2016-07-10T21:12:00.499+02:00"`),
+			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:              "RFC3339Nano string",
+			data:              []byte(`"2016-07-10T21:12:00.499+02:00"`),
+			expectedTimestamp: ToStampMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+		},
+	}
+
+	for _, tc := range testCases {
+		var gotTime TimestampMilli
+		gotErr := gotTime.UnmarshalJSON(tc.data)
+
+		if !tc.expectedTimestamp.Equal(gotTime.T()) {
+			t.Errorf("expected time %s; got %s", tc.expectedTimestamp, gotTime)
+		}
+
+		if (tc.expectedErr == nil && gotErr != nil) ||
+			(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+			t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+		}
+	}
+}
+
+func TestTimestampMilli_UnmarshalText(t *testing.T) {
+	testCases := []struct {
+		name              string
+		data              []byte
+		expectedTimestamp TimestampMilli
+		expectedErr       error
+	}{
+		{
+			name:              "timestamp",
+			data:              []byte(`1468185120499`),
+			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedErr:       nil,
+		},
+		{
+			name:              "RFC3339",
+			data:              []byte(`2016-07-10T21:12:00+02:00`),
+			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:              "RFC3339Milli",
+			data:              []byte(`2016-07-10T21:12:00.499+02:00`),
+			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+		},
+		{
+			name:              "RFC3339Nano",
+			data:              []byte(`2016-07-10T21:12:00.499+02:00`),
+			expectedTimestamp: ToStampMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+		},
+	}
+
+	for _, tc := range testCases {
+		var gotTime TimestampMilli
+		gotErr := gotTime.UnmarshalText(tc.data)
+
+		if !tc.expectedTimestamp.Equal(gotTime.T()) {
+			t.Errorf("expected time %s; got %s", tc.expectedTimestamp, gotTime)
+		}
+
+		if (tc.expectedErr == nil && gotErr != nil) ||
+			(tc.expectedErr != nil && tc.expectedErr.Error() != gotErr.Error()) {
+			t.Errorf("expected error %s; got %s", tc.expectedErr, gotErr)
+		}
+	}
+}


### PR DESCRIPTION
This PR offers two new structures to deal with "instants in time" with millisecond-precision encoding/decoding:
- `xtime.TimeMilli` which is equivalent to `time.Time` with the exceptions that 1) encoding uses xtime.RFC3339Milli layout and 2) decoding handles both Unix timestamps in milliseconds and `xtime.RFC3339Milli` layout,
- `xtime.TimestampMilli` which is equivalent to `time.Time` with the exceptions that 1) encoding uses Unix timestamps in milliseconds and 2) decoding handles both Unix timestamps in milliseconds and `xtime.RFC3339Milli` layout.

`xtime.RFC3339Milli` represents the `RFC339` format will millisecond precision: `2006-01-02T15:04:05.999Z07:00`.