### PR TITLE
[xerrors] Initial version of xerrors package with wrapping and stacktrace functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         golang: [1.14, 1.15, 1.16]
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      XGO_XERRORS_ENABLE_STACK_TRACE: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,5 +98,7 @@ issues:
       linters:
         - dupl
         - funlen
+        - goconst
         - gomnd
         - ifshort
+        - lll

--- a/xerrors/errors.go
+++ b/xerrors/errors.go
@@ -1,0 +1,37 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package xerrors implements functions to manipulate errors.
+// It is meant as a drop-in replacement for the Go standard library error package
+// with additional functionalities inspired by github.com/pkg/errors and
+// github.com/hashicorp/go-multierror packages.
+package xerrors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// New returns an error that formats as the given text.
+// Each call to New returns a distinct error value even if the text is identical.
+// New also records a stack trace at the point it is called if enabled.
+//
+// It is the drop-in replacement for errors.New.
+func New(message string) error {
+	return &withStack{
+		error: errors.New(message),
+		stack: callers(),
+	}
+}
+
+// Newf formats according to a format specifier and returns the string as a value that satisfies error.
+// New also records a stack trace at the point it is called if enabled.
+//
+// It is the equivalent of fmt.Errorf.
+func Newf(format string, args ...interface{}) error {
+	return &withStack{
+		error: fmt.Errorf(format, args...),
+		stack: callers(),
+	}
+}

--- a/xerrors/errors_test.go
+++ b/xerrors/errors_test.go
@@ -1,0 +1,72 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors_test
+
+import (
+	"testing"
+
+	. "github.com/jlourenc/xgo/xerrors"
+)
+
+func TestNew(t *testing.T) {
+	testCases := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name:     "empty message",
+			message:  "",
+			expected: "",
+		},
+		{
+			name:     "non-empty message",
+			message:  "a non-empty message",
+			expected: "a non-empty message",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := New(tc.message)
+
+			if tc.expected != got.Error() {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestNewf(t *testing.T) {
+	testCases := []struct {
+		name     string
+		format   string
+		args     []interface{}
+		expected string
+	}{
+		{
+			name:     "empty format",
+			format:   "",
+			args:     nil,
+			expected: "",
+		},
+		{
+			name:     "non-empty format",
+			format:   "a %s message",
+			args:     []interface{}{"non-empty"},
+			expected: "a non-empty message",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Newf(tc.format, tc.args...)
+
+			if tc.expected != got.Error() {
+				t.Errorf("expected %s; got %s", tc.expected, got)
+			}
+		})
+	}
+}

--- a/xerrors/example_test.go
+++ b/xerrors/example_test.go
@@ -1,0 +1,28 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors_test
+
+import (
+	"fmt"
+
+	"github.com/jlourenc/xgo/xerrors"
+)
+
+func ExampleNew() {
+	err := xerrors.New("emit macho dwarf: elf header corrupted")
+	if err != nil {
+		fmt.Print(err)
+	}
+	// Output: emit macho dwarf: elf header corrupted
+}
+
+func ExampleNewf() {
+	const name, id = "bimmler", 17
+	err := xerrors.Newf("user %q (id %d) not found", name, id)
+	if err != nil {
+		fmt.Print(err)
+	}
+	// Output: user "bimmler" (id 17) not found
+}

--- a/xerrors/stack.go
+++ b/xerrors/stack.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"fmt"
+)
+
+// WithStack annotates err with a stack trace at the point WithStack is called
+// only if enabled and err does not already contain one.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := err.(StackTracer); ok {
+		return err
+	}
+
+	return &withStack{
+		error: err,
+		stack: callers(),
+	}
+}
+
+type withStack struct {
+	error
+	stack
+}
+
+// Format makes withStack implement the fmt.Formatter interface.
+func (e *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", e.Unwrap())
+			if e.stack != nil {
+				e.stack.Format(s, verb)
+			}
+			return
+		}
+		if s.Flag('#') {
+			fmt.Fprintf(s, "%T{error:(%T)(%p), stack:%T%#v}", e, e.Error(), &e.error, e.stack, e.stack)
+			return
+		}
+		fallthrough
+	case 's':
+		fmt.Fprint(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	default:
+		format := fmt.Sprintf("&{%%%%!%%c(%%#v) %%%c}", verb)
+		fmt.Fprintf(s, format, verb, e.error, e.stack)
+	}
+}
+
+// Unwrap makes withStack implement the errors.Unwrapper interface.
+func (e *withStack) Unwrap() error { return e.error }

--- a/xerrors/stack_test.go
+++ b/xerrors/stack_test.go
@@ -1,0 +1,175 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors_test
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	. "github.com/jlourenc/xgo/xerrors"
+)
+
+type (
+	stackError   struct{}
+	unstackError struct{}
+)
+
+func (unstackError) Error() string        { return "unstack error" }
+func (stackError) Error() string          { return "stack error" }
+func (stackError) StackTrace() StackTrace { return []Frame{0, 1, 2, 3} }
+
+func TestWithStack(t *testing.T) {
+	testCases := []struct {
+		name   string
+		err    error
+		assert func(t *testing.T, err error)
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			assert: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("expected nil, got %#v", err)
+				}
+			},
+		},
+		{
+			name: "stack error",
+			err:  stackError{},
+			assert: func(t *testing.T, err error) {
+				if errors.Unwrap(err) != nil || !errors.As(err, &stackError{}) {
+					t.Errorf("expected %#v, got %#v", stackError{}, err)
+				}
+			},
+		},
+		{
+			name: "unstack error",
+			err:  unstackError{},
+			assert: func(t *testing.T, err error) {
+				if errors.Unwrap(err) == nil || !errors.As(err, &unstackError{}) {
+					t.Errorf("expected %#v, got %#v", stackError{}, err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WithStack(tc.err)
+
+			tc.assert(t, got)
+		})
+	}
+}
+
+func TestWithStack_Format(t *testing.T) {
+	testCases := []struct {
+		name             string
+		err              error
+		enableStackTrace bool
+		format           string
+		expected         string
+	}{
+		{
+			name:     "default format",
+			err:      errors.New("error message"),
+			format:   "%v",
+			expected: `^error message$`,
+		},
+		{
+			name:     "default format plus extra with stack trace disabled",
+			err:      errors.New("error message"),
+			format:   "%+v",
+			expected: `^error message$`,
+		},
+		{
+			name:             "default format plus extra with stack trace enabled",
+			err:              errors.New("error message"),
+			enableStackTrace: true,
+			format:           "%+v",
+			expected:         `^error message(\n(\t)?[0-9a-zA-Z.\/_:-]+)+$`,
+		},
+		{
+			name:     "Go-syntax representation of the value with stack trace disabled",
+			err:      errors.New("error message"),
+			format:   "%#v",
+			expected: `^\*xerrors\.withStack\{error:\(string\)\(0x[a-f0-9]+\), stack:xerrors\.stack\(nil\)\}$`,
+		},
+		{
+			name:             "Go-syntax representation of the value with stack trace enabled",
+			err:              errors.New("error message"),
+			enableStackTrace: true,
+			format:           "%#v",
+			expected:         `^\*xerrors\.withStack\{error:\(string\)\(0x[a-f0-9]+\), stack:xerrors\.stack\[([0-9]+[ ]?){3}\]\}$`,
+		},
+		{
+			name:     "string format",
+			err:      errors.New("error message"),
+			format:   "%s",
+			expected: `^error message$`,
+		},
+		{
+			name:     "double-quoted string format",
+			err:      errors.New("error message"),
+			format:   "%q",
+			expected: `^"error message"$`,
+		},
+		{
+			name:     "Go-syntax representation of the type of the value",
+			err:      errors.New("error message"),
+			format:   "%T",
+			expected: `^\*xerrors\.withStack$`,
+		},
+		{
+			name:             "unsupported format",
+			err:              errors.New("error message"),
+			enableStackTrace: true,
+			format:           "%t",
+			expected:         `^\&\{\%\!t\(\&errors\.errorString\{s:"error message"\}\) \[(\%\!t\(uintptr=[0-9]+\)[ ]?){3}\]\}$`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			EnableStackTrace(tc.enableStackTrace)
+			defer EnableStackTrace(!tc.enableStackTrace)
+
+			got := fmt.Sprintf(tc.format, WithStack(tc.err))
+
+			re, err := regexp.Compile(tc.expected)
+			if err != nil {
+				t.Fatalf("invalid regex: %s", tc.expected)
+			}
+			if !re.MatchString(got) {
+				t.Errorf("expected pattern %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestWithStack_Unwrap(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{
+			name:     "unwrap",
+			err:      WithStack(&unstackError{}),
+			expected: &unstackError{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.err.(interface{ Unwrap() error }).Unwrap()
+
+			if got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}

--- a/xerrors/stackframe.go
+++ b/xerrors/stackframe.go
@@ -1,0 +1,226 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const (
+	numStackFramesToSkip = 3
+	stacktraceDepth      = 32
+	unknown              = "unknown"
+)
+
+var (
+	callers          func() stack
+	enableStackTrace = false
+)
+
+func init() {
+	v, ok := os.LookupEnv("XGO_XERRORS_ENABLE_STACK_TRACE")
+	if b, err := strconv.ParseBool(v); ok && err == nil {
+		enableStackTrace = b
+	}
+
+	EnableStackTrace(enableStackTrace)
+}
+
+// EnableStackTrace permits enabling/disabling programmatically the stack trace functionality.
+// It is NOT thread-safe.
+func EnableStackTrace(enable bool) {
+	if !enable {
+		callers = func() stack { return nil }
+		return
+	}
+
+	callers = func() stack {
+		var pcs [stacktraceDepth]uintptr
+		n := runtime.Callers(numStackFramesToSkip, pcs[:])
+		return pcs[0:n]
+	}
+}
+
+// Frame represents a program counter inside a stack frame.
+// For historical reasons if Frame is interpreted as a uintptr
+// its value represents the program counter + 1.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return unknown
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// name returns the name of this function, if known.
+func (f Frame) name() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return unknown
+	}
+	return fn.Name()
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			fmt.Fprint(s, f.name(), "\n\t", f.file())
+		default:
+			fmt.Fprint(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprint(s, strconv.Itoa(f.line()))
+	case 'n':
+		fmt.Fprint(s, funcname(f.name()))
+	case 'v':
+		f.Format(s, 's')
+		fmt.Fprint(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// MarshalText formats a stacktrace Frame as a text string. The output is the
+// same as that of fmt.Sprintf("%+v", f), but without newlines or tabs.
+func (f Frame) MarshalText() ([]byte, error) {
+	name := f.name()
+	if name == unknown {
+		return []byte(name), nil
+	}
+	return []byte(fmt.Sprintf("%s %s:%d", name, f.file(), f.line())), nil
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprint(s, "\n")
+				f.Format(s, verb)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			st.formatSlice(s, verb)
+		}
+	case 's':
+		st.formatSlice(s, verb)
+	}
+}
+
+// formatSlice will format this StackTrace into the given buffer as a slice of
+// Frame, only valid when called with '%s' or '%v'.
+func (st StackTrace) formatSlice(s fmt.State, verb rune) {
+	fmt.Fprint(s, "[")
+	for i, f := range st {
+		if i > 0 {
+			fmt.Fprint(s, " ")
+		}
+		f.Format(s, verb)
+	}
+	fmt.Fprint(s, "]")
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+// StackTracer is implemented by any value that has a StackTrace method.
+// The implementation returns a stack of Frames from innermost (newest) to outermost (oldest).
+type StackTracer interface {
+	StackTrace() StackTrace
+}
+
+// Format implements the fmt.Formatter interface.
+func (s stack) Format(st fmt.State, verb rune) {
+	if verb == 'v' && st.Flag('+') {
+		for _, pc := range s {
+			fmt.Fprintf(st, "\n%+v", Frame(pc))
+		}
+		return
+	}
+
+	if verb == 'v' && st.Flag('#') {
+		if s == nil {
+			fmt.Fprint(st, "(nil)")
+		} else {
+			fmt.Fprintf(st, "%v", []uintptr(s))
+		}
+		return
+	}
+
+	format := fmt.Sprintf("%%%c", verb)
+	fmt.Fprintf(st, format, []uintptr(s))
+}
+
+// StackTrace returns a stack trace.
+func (s stack) StackTrace() StackTrace {
+	if s == nil {
+		return nil
+	}
+
+	f := make([]Frame, len(s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((s)[i])
+	}
+	return f
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/xerrors/stackframe_test.go
+++ b/xerrors/stackframe_test.go
@@ -1,0 +1,180 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors_test
+
+import (
+	"fmt"
+	"regexp"
+	"runtime"
+	"testing"
+
+	. "github.com/jlourenc/xgo/xerrors"
+)
+
+func TestFrame_Format(t *testing.T) {
+	var pcs [1]uintptr
+	runtime.Callers(1, pcs[:])
+
+	testCases := []struct {
+		name     string
+		format   string
+		frame    Frame
+		expected string
+	}{
+		{
+			name:     "source file",
+			format:   "%s",
+			frame:    Frame(pcs[0]),
+			expected: `^stackframe_test.go$`,
+		},
+		{
+			name:     "source file plus extra",
+			format:   "%+s",
+			frame:    Frame(pcs[0]),
+			expected: `^github\.com\/jlourenc\/xgo\/xerrors_test\.TestFrame_Format\n\t.*\/xgo\/xerrors\/stackframe_test\.go$`,
+		},
+		{
+			name:     "source line",
+			format:   "%d",
+			frame:    Frame(pcs[0]),
+			expected: `^18$`,
+		},
+		{
+			name:     "function name",
+			format:   "%n",
+			frame:    Frame(pcs[0]),
+			expected: `^TestFrame_Format$`,
+		},
+		{
+			name:     "source file and line",
+			format:   "%v",
+			frame:    Frame(pcs[0]),
+			expected: `^stackframe_test\.go:18$`,
+		},
+		{
+			name:     "source file and line plus extra of unknown frame",
+			format:   "%+v",
+			frame:    Frame(0),
+			expected: `^unknown\n\tunknown:0$`,
+		},
+		{
+			name:     "source file and line plus extra",
+			format:   "%+v",
+			frame:    Frame(pcs[0]),
+			expected: `^github.com\/jlourenc\/xgo\/xerrors_test\.TestFrame_Format\n\t.*\/xgo\/xerrors\/stackframe_test\.go:18$`,
+		},
+		{
+			name:     "unsupported format",
+			format:   "%t",
+			frame:    Frame(pcs[0]),
+			expected: `^$`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fmt.Sprintf(tc.format, tc.frame)
+
+			re, err := regexp.Compile(tc.expected)
+			if err != nil {
+				t.Fatalf("invalid regex: %s", tc.expected)
+			}
+			if !re.MatchString(got) {
+				t.Errorf("expected pattern %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestFrame_MarshalText(t *testing.T) {
+	var pcs [1]uintptr
+	runtime.Callers(1, pcs[:])
+
+	testCases := []struct {
+		name     string
+		frame    Frame
+		expected string
+	}{
+		{
+			name:     "known frame",
+			frame:    Frame(pcs[0]),
+			expected: `^github.com\/jlourenc\/xgo\/xerrors_test\.TestFrame_MarshalText .*\/xgo\/xerrors\/stackframe_test\.go:93$`,
+		},
+		{
+			name:     "unknown frame",
+			frame:    Frame(0),
+			expected: `^unknown$`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.frame.MarshalText()
+
+			if err != nil {
+				t.Fatalf("error is not expected")
+			}
+
+			re, err := regexp.Compile(tc.expected)
+			if err != nil {
+				t.Fatalf("invalid regex: %s", tc.expected)
+			}
+			if !re.MatchString(string(got)) {
+				t.Errorf("expected pattern %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestStackTrace_Format(t *testing.T) {
+	var pcs [2]uintptr
+	runtime.Callers(1, pcs[:])
+
+	testCases := []struct {
+		name       string
+		format     string
+		stackTrace StackTrace
+		expected   string
+	}{
+		{
+			name:       "lists source files",
+			format:     "%s",
+			stackTrace: StackTrace{Frame(pcs[0]), Frame(pcs[1])},
+			expected:   `^\[stackframe_test\.go testing\.go\]$`,
+		},
+		{
+			name:       "lists source files and line numbers",
+			format:     "%v",
+			stackTrace: StackTrace{Frame(pcs[0])},
+			expected:   `^\[stackframe_test\.go:133\]$`,
+		},
+		{
+			name:       "lists source files, line numbers and function names",
+			format:     "%+v",
+			stackTrace: StackTrace{Frame(pcs[0])},
+			expected:   `^\ngithub\.com\/jlourenc\/xgo\/xerrors_test\.TestStackTrace_Format\n\t.*\/xgo\/xerrors\/stackframe_test\.go:133$`,
+		},
+		{
+			name:       "source file and line plus extra",
+			format:     "%#v",
+			stackTrace: StackTrace{Frame(pcs[0])},
+			expected:   `^\[\]xerrors\.Frame\{stackframe_test\.go:133\}$`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fmt.Sprintf(tc.format, tc.stackTrace)
+
+			re, err := regexp.Compile(tc.expected)
+			if err != nil {
+				t.Fatalf("invalid regex: %s", tc.expected)
+			}
+			if !re.MatchString(got) {
+				t.Errorf("expected pattern %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}

--- a/xerrors/wrap.go
+++ b/xerrors/wrap.go
@@ -1,0 +1,142 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true. Otherwise, it returns false.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// An error type might provide an As method so it can be treated as if it were a
+// different error type.
+//
+// As panics if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type.
+//
+// It is the drop-in replacement for errors.As.
+func As(err error, target interface{}) bool {
+	return errors.As(err, target)
+}
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+//
+// An error type might provide an Is method so it can be treated as equivalent
+// to an existing error. For example, if MyError defines
+//
+//		func (m MyError) Is(target error) bool { return target == fs.ErrExist }
+//
+// then Is(MyError{}, fs.ErrExist) returns true. See syscall.Errno.Is for
+// an example in the standard library.
+//
+// It is the drop-in replacement for errors.Is.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+//
+// Is is the drop-in replacement for errors.Unwrap.
+func Unwrap(err error) error {
+	return errors.Unwrap(err)
+}
+
+// Wrap returns an error annotating err with the supplied message and a stack trace,
+// if enabled and err does not already contain one, at the point Wrap is called.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := err.(StackTracer); !ok {
+		err = &withStack{
+			error: err,
+			stack: callers(),
+		}
+	}
+
+	return &withWrap{
+		err: err,
+		msg: message,
+	}
+}
+
+// Wrapf returns an error annotating err with the format specifier and a stack trace,
+// if enabled and err does not already contain one, at the point Wrap is called.
+// If err is nil, Wrap returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := err.(StackTracer); !ok {
+		err = &withStack{
+			error: err,
+			stack: callers(),
+		}
+	}
+
+	return &withWrap{
+		err: err,
+		msg: fmt.Sprintf(format, args...),
+	}
+}
+
+type withWrap struct {
+	msg string
+	err error
+}
+
+// Error makes withWrap implement the error interface.
+func (e *withWrap) Error() string { return e.msg + ": " + e.err.Error() }
+
+// Format makes withWrap implement the fmt.Formatter interface.
+func (e *withWrap) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%s: %+v", e.msg, e.Unwrap())
+			return
+		}
+		if s.Flag('#') {
+			fmt.Fprintf(s, "%T{msg:%q, err:(%T)(%p)}", e, e.Error(), e.err, &e.err)
+			return
+		}
+		fallthrough
+	case 's':
+		fmt.Fprint(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	default:
+		fmt.Fprintf(s, "&{%%!%c(%T=%s) %%!%c(%#v)}", verb, e.msg, e.Error(), verb, e.err)
+	}
+}
+
+// StackTrace makes withWrap implement the StackTracer interface.
+func (e *withWrap) StackTrace() StackTrace {
+	return e.err.(StackTracer).StackTrace()
+}
+
+// Unwrap makes withWrap implement the errors.Unwrapper interface.
+func (e *withWrap) Unwrap() error { return e.err }

--- a/xerrors/wrap_test.go
+++ b/xerrors/wrap_test.go
@@ -1,0 +1,366 @@
+// Copyright 2021 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors_test
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	. "github.com/jlourenc/xgo/xerrors"
+)
+
+func TestAs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		target   interface{}
+		expected bool
+	}{
+		{
+			name:     "matches",
+			err:      fmt.Errorf("wrapped error: %w", unstackError{}),
+			target:   &unstackError{},
+			expected: true,
+		},
+		{
+			name:     "does not match",
+			err:      fmt.Errorf("wrapped error: %w", stackError{}),
+			target:   &unstackError{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := As(tc.err, tc.target)
+
+			if tc.expected != got {
+				t.Errorf("expected %t, got %t", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestIs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		target   error
+		expected bool
+	}{
+		{
+			name:     "matches",
+			err:      fmt.Errorf("wrapped error: %w", unstackError{}),
+			target:   unstackError{},
+			expected: true,
+		},
+		{
+			name:     "does not match",
+			err:      fmt.Errorf("wrapped error: %w", stackError{}),
+			target:   unstackError{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Is(tc.err, tc.target)
+
+			if tc.expected != got {
+				t.Errorf("expected %t, got %t", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{
+			name:     "simple error",
+			err:      unstackError{},
+			expected: nil,
+		},
+		{
+			name:     "wrapped error",
+			err:      fmt.Errorf("wrapped error: %w", unstackError{}),
+			expected: unstackError{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Unwrap(tc.err)
+
+			if tc.expected != got {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestWrap(t *testing.T) {
+	testCases := []struct {
+		name   string
+		err    error
+		assert func(t *testing.T, err error)
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			assert: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("expected nil, got %#v", err)
+				}
+			},
+		},
+		{
+			name: "stack error",
+			err:  stackError{},
+			assert: func(t *testing.T, err error) {
+				if errors.Unwrap(err) == nil || !errors.As(err, &stackError{}) || err.Error() != "wrap: stack error" {
+					t.Errorf("expected %#v, got %#v", stackError{}, err)
+				}
+			},
+		},
+		{
+			name: "unstack error",
+			err:  unstackError{},
+			assert: func(t *testing.T, err error) {
+				if errors.Unwrap(err) == nil || !errors.As(err, &unstackError{}) || err.Error() != "wrap: unstack error" {
+					t.Errorf("expected %#v, got %#v", stackError{}, err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Wrap(tc.err, "wrap")
+
+			tc.assert(t, got)
+		})
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	testCases := []struct {
+		name   string
+		err    error
+		assert func(t *testing.T, err error)
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			assert: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("expected nil, got %#v", err)
+				}
+			},
+		},
+		{
+			name: "stack error",
+			err:  stackError{},
+			assert: func(t *testing.T, err error) {
+				if errors.Unwrap(err) == nil || !errors.As(err, &stackError{}) || err.Error() != "wrap: stack error" {
+					t.Errorf("expected %#v, got %#v", stackError{}, err)
+				}
+			},
+		},
+		{
+			name: "unstack error",
+			err:  unstackError{},
+			assert: func(t *testing.T, err error) {
+				if errors.Unwrap(err) == nil || !errors.As(err, &unstackError{}) || err.Error() != "wrap: unstack error" {
+					t.Errorf("expected %#v, got %#v", stackError{}, err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Wrapf(tc.err, "%s", "wrap")
+
+			tc.assert(t, got)
+		})
+	}
+}
+
+func TestWithWrap_Error(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "error",
+			err:      Wrap(&stackError{}, "wrap"),
+			expected: "wrap: stack error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.err.Error()
+
+			if tc.expected != got {
+				t.Errorf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestWithWrap_Format(t *testing.T) {
+	testCases := []struct {
+		name             string
+		err              error
+		enableStackTrace bool
+		format           string
+		expected         string
+	}{
+		{
+			name:     "default format",
+			err:      errors.New("error message"),
+			format:   "%v",
+			expected: `wrapped: error message`,
+		},
+		{
+			name:     "default format plus extra with stack trace disabled",
+			err:      Wrap(errors.New("error message"), "wrapped 0"),
+			format:   "%+v",
+			expected: `wrapped: wrapped 0: error message`,
+		},
+		{
+			name:             "default format plus extra with stack trace enabled",
+			err:              errors.New("error message"),
+			enableStackTrace: true,
+			format:           "%+v",
+			expected:         `^wrapped: error message(\n(\t)?[0-9a-zA-Z.\/_:-]+)+$`,
+		},
+		{
+			name:     "Go-syntax representation of the value with stack trace disabled",
+			err:      errors.New("error message"),
+			format:   "%#v",
+			expected: `\*xerrors\.withWrap\{msg:"wrapped: error message", err:\(\*xerrors\.withStack\)\(0x[a-f0-9]+\)\}`,
+		},
+		{
+			name:             "Go-syntax representation of the value with stack trace enabled",
+			err:              errors.New("error message"),
+			enableStackTrace: true,
+			format:           "%#v",
+			expected:         `\*xerrors\.withWrap\{msg:"wrapped: error message", err:\(\*xerrors\.withStack\)\(0x[a-f0-9]+\)\}`,
+		},
+		{
+			name:     "string format",
+			err:      errors.New("error message"),
+			format:   "%s",
+			expected: `wrapped: error message`,
+		},
+		{
+			name:     "double-quoted string format",
+			err:      errors.New("error message"),
+			format:   "%q",
+			expected: `"wrapped: error message"`,
+		},
+		{
+			name:     "Go-syntax representation of the type of the value",
+			err:      errors.New("error message"),
+			format:   "%T",
+			expected: `\*xerrors\.withWrap`,
+		},
+		{
+			name:             "unsupported format",
+			err:              errors.New("error message"),
+			enableStackTrace: true,
+			format:           "%t",
+			expected:         `\&\{\%\!t\(string=wrapped: error message\) \%\!t\(\*xerrors\.withStack\{error:\(string\)\(0x[a-f0-9]+\), stack:xerrors\.stack\[([0-9]+[ ]?){3}\]\}\)\}`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			EnableStackTrace(tc.enableStackTrace)
+			defer EnableStackTrace(!tc.enableStackTrace)
+
+			got := fmt.Sprintf(tc.format, Wrap(tc.err, "wrapped"))
+
+			re, err := regexp.Compile(tc.expected)
+			if err != nil {
+				t.Fatalf("invalid regex: %s", tc.expected)
+			}
+			if !re.MatchString(got) {
+				t.Errorf("expected pattern %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestWithWrap_StackTrace(t *testing.T) {
+	testCases := []struct {
+		name             string
+		err              error
+		enableStackTrace bool
+		expectedSize     int
+	}{
+		{
+			name:         "stack error",
+			err:          &stackError{},
+			expectedSize: 4,
+		},
+		{
+			name:         "unstack error with stack trace disabled",
+			err:          &unstackError{},
+			expectedSize: 0,
+		},
+		{
+			name:             "unstack error with stack trace enabled",
+			err:              &unstackError{},
+			enableStackTrace: true,
+			expectedSize:     3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			EnableStackTrace(tc.enableStackTrace)
+			defer EnableStackTrace(!tc.enableStackTrace)
+
+			got := Wrap(tc.err, "wrapped").(interface{ StackTrace() StackTrace }).StackTrace()
+
+			if len(got) != tc.expectedSize {
+				t.Fatalf("expected stack trace of size %d, got %v", tc.expectedSize, got)
+			}
+		})
+	}
+}
+
+func TestWithWrap_Unwrap(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{
+			name:     "unwrap",
+			err:      Wrap(&stackError{}, ""),
+			expected: &stackError{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.err.(interface{ Unwrap() error }).Unwrap()
+
+			if got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR offers a drop-in replacement package for error handling. The package provides convenience functions to wrap errors with optional stack traces.