### PR TITLE
[xnet] Use localhost to ask kernel for free open port

### DIFF
--- a/xnet/port.go
+++ b/xnet/port.go
@@ -23,14 +23,14 @@ func FreePort(ctx context.Context, network string, options ...ListenConfigOption
 
 	switch network {
 	case NetworkTCP, NetworkTCP4, NetworkTCP6:
-		listener, err := lc.Listen(ctx, network, ":0")
+		listener, err := lc.Listen(ctx, network, "localhost:0")
 		if err != nil {
 			return 0, err
 		}
 		defer listener.Close()
 		return listener.Addr().(*net.TCPAddr).Port, nil
 	case NetworkUDP, NetworkUDP4, NetworkUDP6:
-		listener, err := lc.ListenPacket(ctx, network, ":0")
+		listener, err := lc.ListenPacket(ctx, network, "localhost:0")
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
To suppress the mac security popup (https://egel.github.io/development/2018/06/16/accept-incoming-network-connections.html), make use of `localhost` as `hostname` for getting a free open port.