### PR TITLE
Upgrade golangci-lint to v1.44 and add a few linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.41
+          version: v1.44
   # tests
   go-test:
     needs: golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,11 +6,10 @@ linters-settings:
     threshold: 100
   errcheck:
     check-blank: true
+    check-type-assertions: true
   funlen:
     lines: 100
     statements: 50
-  gci:
-    local-prefixes: github.com/jlourenc/xgo
   gocognit:
     min-complexity: 25
   goconst:
@@ -35,12 +34,10 @@ linters-settings:
     check-shadowing: true
   lll:
     line-length: 140
-  nestif:
-    min-complexity: 6
-  maligned:
-    suggest-new: true
   misspell:
     locale: US
+  nestif:
+    min-complexity: 6
   nolintlint:
     allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
@@ -50,21 +47,23 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
     - bodyclose
+    - contextcheck
     - deadcode
     - depguard
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
-    - exportloopref
     - exhaustive
+    - exportloopref
     - funlen
     - gocognit
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - gofmt
     - goimports
     - gomnd
     - goprintffuncname
@@ -78,6 +77,7 @@ linters:
     - nakedret
     - nestif
     - nilerr
+    - nilnil
     - noctx
     - nolintlint
     - prealloc
@@ -86,6 +86,8 @@ linters:
     - structcheck
     - stylecheck
     - testpackage
+    - thelper
+    - tparallel
     - typecheck
     - unconvert
     - unparam

--- a/xerrors/stack_test.go
+++ b/xerrors/stack_test.go
@@ -32,6 +32,7 @@ func TestWithStack(t *testing.T) {
 			name: "nil",
 			err:  nil,
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if err != nil {
 					t.Errorf("expected nil, got %#v", err)
 				}
@@ -41,6 +42,7 @@ func TestWithStack(t *testing.T) {
 			name: "stack error",
 			err:  stackError{},
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if errors.Unwrap(err) != nil || !errors.As(err, &stackError{}) {
 					t.Errorf("expected %#v, got %#v", stackError{}, err)
 				}
@@ -50,6 +52,7 @@ func TestWithStack(t *testing.T) {
 			name: "unstack error",
 			err:  unstackError{},
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if errors.Unwrap(err) == nil || !errors.As(err, &unstackError{}) {
 					t.Errorf("expected %#v, got %#v", stackError{}, err)
 				}

--- a/xerrors/wrap_test.go
+++ b/xerrors/wrap_test.go
@@ -116,6 +116,7 @@ func TestWrap(t *testing.T) {
 			name: "nil",
 			err:  nil,
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if err != nil {
 					t.Errorf("expected nil, got %#v", err)
 				}
@@ -125,6 +126,7 @@ func TestWrap(t *testing.T) {
 			name: "stack error",
 			err:  stackError{},
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if errors.Unwrap(err) == nil || !errors.As(err, &stackError{}) || err.Error() != "wrap: stack error" {
 					t.Errorf("expected %#v, got %#v", stackError{}, err)
 				}
@@ -134,6 +136,7 @@ func TestWrap(t *testing.T) {
 			name: "unstack error",
 			err:  unstackError{},
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if errors.Unwrap(err) == nil || !errors.As(err, &unstackError{}) || err.Error() != "wrap: unstack error" {
 					t.Errorf("expected %#v, got %#v", stackError{}, err)
 				}
@@ -160,6 +163,7 @@ func TestWrapf(t *testing.T) {
 			name: "nil",
 			err:  nil,
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if err != nil {
 					t.Errorf("expected nil, got %#v", err)
 				}
@@ -169,6 +173,7 @@ func TestWrapf(t *testing.T) {
 			name: "stack error",
 			err:  stackError{},
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if errors.Unwrap(err) == nil || !errors.As(err, &stackError{}) || err.Error() != "wrap: stack error" {
 					t.Errorf("expected %#v, got %#v", stackError{}, err)
 				}
@@ -178,6 +183,7 @@ func TestWrapf(t *testing.T) {
 			name: "unstack error",
 			err:  unstackError{},
 			assert: func(t *testing.T, err error) {
+				t.Helper()
 				if errors.Unwrap(err) == nil || !errors.As(err, &unstackError{}) || err.Error() != "wrap: unstack error" {
 					t.Errorf("expected %#v, got %#v", stackError{}, err)
 				}

--- a/xnet/dial_test.go
+++ b/xnet/dial_test.go
@@ -27,6 +27,8 @@ func listenTCP() (net.Listener, string, error) {
 }
 
 func assertDial(t *testing.T, expectedErr bool, conn net.Conn, err error) {
+	t.Helper()
+
 	if expectedErr {
 		if conn != nil {
 			t.Errorf("expected no connection, got %v", conn)

--- a/xnet/net_test.go
+++ b/xnet/net_test.go
@@ -22,6 +22,7 @@ func TestConn_Read(t *testing.T) {
 		{
 			name: "connection already closed",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				ln, conn := dialTCPWithReadHandler(t, DialReadTimeout(5*time.Second))
 				conn.Close()
 				return ln, conn
@@ -31,6 +32,7 @@ func TestConn_Read(t *testing.T) {
 		{
 			name: "no read timeout",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				return dialTCPWithReadHandler(t)
 			},
 			expectedErr: false,
@@ -38,6 +40,7 @@ func TestConn_Read(t *testing.T) {
 		{
 			name: "with negative read timeout",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				return dialTCPWithReadHandler(t, DialReadTimeout(-5*time.Second))
 			},
 			expectedErr: true,
@@ -45,6 +48,7 @@ func TestConn_Read(t *testing.T) {
 		{
 			name: "with positive read timeout",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				return dialTCPWithReadHandler(t, DialReadTimeout(5*time.Second))
 			},
 			expectedErr: false,
@@ -75,6 +79,7 @@ func TestConn_Write(t *testing.T) {
 		{
 			name: "connection already closed",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				ln, conn := dialTCPWithWriteHandler(t, DialWriteTimeout(5*time.Second))
 				conn.Close()
 				return ln, conn
@@ -84,6 +89,7 @@ func TestConn_Write(t *testing.T) {
 		{
 			name: "no write timeout",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				return dialTCPWithWriteHandler(t)
 			},
 			expectedErr: false,
@@ -91,6 +97,7 @@ func TestConn_Write(t *testing.T) {
 		{
 			name: "with negative write timeout",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				return dialTCPWithWriteHandler(t, DialWriteTimeout(-5*time.Second))
 			},
 			expectedErr: true,
@@ -98,6 +105,7 @@ func TestConn_Write(t *testing.T) {
 		{
 			name: "with positive write timeout",
 			setup: func(t *testing.T) (net.Listener, net.Conn) {
+				t.Helper()
 				return dialTCPWithWriteHandler(t, DialWriteTimeout(5*time.Second))
 			},
 			expectedErr: false,
@@ -119,6 +127,8 @@ func TestConn_Write(t *testing.T) {
 }
 
 func assertOperation(t *testing.T, expectedErr bool, n int, err error) {
+	t.Helper()
+
 	if expectedErr {
 		if n != 0 {
 			t.Errorf("expected no bytes, got %d bytes", n)
@@ -166,6 +176,8 @@ func dialTCP(handler func(net.Conn) error, options ...DialOption) (net.Listener,
 }
 
 func dialTCPWithReadHandler(t *testing.T, options ...DialOption) (net.Listener, net.Conn) {
+	t.Helper()
+
 	ln, conn, err := dialTCP(func(conn net.Conn) error {
 		_, err := conn.Write([]byte("pong"))
 		return err
@@ -177,6 +189,8 @@ func dialTCPWithReadHandler(t *testing.T, options ...DialOption) (net.Listener, 
 }
 
 func dialTCPWithWriteHandler(t *testing.T, options ...DialOption) (net.Listener, net.Conn) {
+	t.Helper()
+
 	ln, conn, err := dialTCP(func(conn net.Conn) error {
 		_, err := conn.Read(make([]byte, 4))
 		return err

--- a/xtime/time_test.go
+++ b/xtime/time_test.go
@@ -5,6 +5,7 @@
 package xtime_test
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 	"time"
@@ -316,7 +317,7 @@ func TestTimeMilli_MarshalJSON(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotBytes, gotErr := tc.time.MarshalJSON()
 
-			if string(tc.expectedBytes) != string(gotBytes) {
+			if !bytes.Equal(tc.expectedBytes, gotBytes) {
 				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
 			}
 
@@ -359,7 +360,7 @@ func TestTimeMilli_MarshalText(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotBytes, gotErr := tc.time.MarshalText()
 
-			if string(tc.expectedBytes) != string(gotBytes) {
+			if !bytes.Equal(tc.expectedBytes, gotBytes) {
 				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
 			}
 

--- a/xtime/timestamp_test.go
+++ b/xtime/timestamp_test.go
@@ -5,6 +5,7 @@
 package xtime_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -309,7 +310,7 @@ func TestTimestampMilli_MarshalJSON(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotBytes, gotErr := tc.timestamp.MarshalJSON()
 
-			if string(tc.expectedBytes) != string(gotBytes) {
+			if !bytes.Equal(tc.expectedBytes, gotBytes) {
 				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
 			}
 
@@ -346,7 +347,7 @@ func TestTimestampMilli_MarshalText(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotBytes, gotErr := tc.timestamp.MarshalText()
 
-			if string(tc.expectedBytes) != string(gotBytes) {
+			if !bytes.Equal(tc.expectedBytes, gotBytes) {
 				t.Errorf("expected bytes %s; got %s", tc.expectedBytes, gotBytes)
 			}
 


### PR DESCRIPTION
- switches from `golangci-lint` `v1.41` to `v1.44`
- adds linters: `bidichk`, `contextcheck, `durationcheck`, `nilnil`, `thelper` and `tparallel`