### PR TITLE
ci(lint): upgrade golangci-lint to 1.50.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48
+          version: v1.50
   # tests
   test:
     needs: lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,4 @@
 linters-settings:
-  depguard:
-    list-type: allowlist
-    include-go-root: false
   dupl:
     threshold: 100
   errcheck:
@@ -10,8 +7,6 @@ linters-settings:
   funlen:
     lines: 100
     statements: 50
-  gocognit:
-    min-complexity: 25
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -24,40 +19,59 @@ linters-settings:
       - style
   gocyclo:
     min-complexity: 15
+  godot:
+    capital: true
+  goheader:
+    template: |-
+      Copyright {{ YEAR }} Jérémy Lourenço. All rights reserved.
+      Use of this source code is governed by a BSD-style
+      license that can be found in the LICENSE file.
   goimports:
     local-prefixes: github.com/jlourenc/xgo
   gomnd:
-    settings:
-      mnd:
-        checks: argument,case,condition,operation,return,assign
-        ignored-numbers:
-          - '2'
-          - '10'
-          - '10.0'
-          - '64'
+    ignored-numbers:
+      - '2'
+      - '10'
+      - '10.0'
+      - '16'
+      - '32'
+      - '64'
   gomodguard:
     allowed:
       modules: []
       domains: []
   gosimple:
-    go: 1.19
     checks: [all]
+    settings:
+      shadow:
+        strict: true
   govet:
     check-shadowing: true
   lll:
     line-length: 140
   misspell:
     locale: US
-  nestif:
-    min-complexity: 6
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    require-explanation: true
+    require-specific: true
+  prealloc:
+    for-loops: true
   staticcheck:
-    go: 1.19
     checks: [all]
+  stylecheck:
+    checks: [all]
+    http-status-code-whitelist: []
+  tenv:
+    all: true
+  usestdlibvars:
+    constant-kind: true
+    crypto-hash: true
+    default-rpc-path: true
+    os-dev-null: true
+    sql-isolation-level: true
+    time-layout: true
+    time-month: true
+    tls-signature-scheme: true
 linters:
   disable-all: true
   enable:
@@ -66,21 +80,21 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - deadcode
     - dogsled
     - dupl
     - durationcheck
     - errcheck
-    - errchkjson
+    - execinquery
     - exhaustive
     - exportloopref
+    - forbidigo
     - funlen
-    - gocognit
     - goconst
     - gocritic
     - gocyclo
     - godot
     - godox
+    - goheader
     - goimports
     - gomnd
     - gomodguard
@@ -88,7 +102,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - lll
@@ -100,12 +113,13 @@ linters:
     - nilnil
     - noctx
     - nolintlint
+    - nosprintfhostport
     - prealloc
     - predeclared
+    - reassign
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tagliatelle
     - tenv
@@ -116,7 +130,7 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
+    - usestdlibvars
     - wastedassign
     - whitespace
 issues:
@@ -128,5 +142,4 @@ issues:
         - funlen
         - goconst
         - gomnd
-        - ifshort
         - lll

--- a/xio/example_test.go
+++ b/xio/example_test.go
@@ -20,7 +20,10 @@ func ExampleDrainClose() {
 		log.Fatalf("Failed to drain and close ReadCloser: %v", err)
 	}
 
-	log.Print("ReadCloser drained and closed")
+	b, _ := io.ReadAll(rc)
+
+	fmt.Printf("%s\n", b)
+	// Output:
 }
 
 func ExampleDuplicateReader() {

--- a/xnet/dial_test.go
+++ b/xnet/dial_test.go
@@ -29,20 +29,14 @@ func listenTCP() (net.Listener, string, error) {
 func assertDial(t *testing.T, expectedErr bool, conn net.Conn, err error) {
 	t.Helper()
 
-	if expectedErr {
-		if conn != nil {
-			t.Errorf("expected no connection, got %v", conn)
-		}
-		if err == nil {
-			t.Error("expected error, got nil")
-		}
-	} else {
-		if conn == nil {
-			t.Error("expected connection, got nil")
-		}
-		if err != nil {
-			t.Errorf("expected no error, got %s", err)
-		}
+	isErrNil := err == nil
+	if expectedErr == isErrNil {
+		t.Errorf("expected error is %t, got %v", expectedErr, err)
+	}
+
+	isConnNil := conn == nil
+	if expectedErr != isConnNil {
+		t.Errorf("expected connection is %t, got %v", !expectedErr, conn)
 	}
 }
 

--- a/xnet/example_test.go
+++ b/xnet/example_test.go
@@ -42,6 +42,7 @@ func ExampleDialContext() {
 
 	log.Print("Connection established")
 }
+
 func ExampleDialer_Dial() {
 	d := xnet.Dialer{
 		ReadTimeout:  time.Second,

--- a/xnet/net_test.go
+++ b/xnet/net_test.go
@@ -129,20 +129,14 @@ func TestConn_Write(t *testing.T) {
 func assertOperation(t *testing.T, expectedErr bool, n int, err error) {
 	t.Helper()
 
-	if expectedErr {
-		if n != 0 {
-			t.Errorf("expected no bytes, got %d bytes", n)
-		}
-		if err == nil {
-			t.Error("expected error, got nil")
-		}
-	} else {
-		if n == 0 {
-			t.Error("expected bytes, got no bytes")
-		}
-		if err != nil {
-			t.Errorf("expected no error, got %s", err)
-		}
+	isErrNil := err == nil
+	if expectedErr == isErrNil {
+		t.Errorf("expected error is %t, got %v", expectedErr, err)
+	}
+
+	noBytes := n == 0
+	if expectedErr != noBytes {
+		t.Errorf("expected bytes is %t, got %d bytes", !expectedErr, n)
 	}
 }
 

--- a/xnet/port.go
+++ b/xnet/port.go
@@ -44,7 +44,7 @@ func FreePort(ctx context.Context, network string, options ...ListenConfigOption
 // ParsePort parses a string representing a port.
 // If the string is not a valid port number, an error is returned.
 func ParsePort(port string, allowZero bool) (int, error) {
-	p, err := strconv.ParseUint(port, 10, 16) //nolint:gomnd // Base 10 number in range [0, 2^16-1]
+	p, err := strconv.ParseUint(port, 10, 16) // base 10 number in range [0, 2^16-1]
 	if err != nil {
 		return 0, err
 	}

--- a/xnet/port_test.go
+++ b/xnet/port_test.go
@@ -64,20 +64,14 @@ func TestFreePort(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			port, err := FreePort(context.Background(), tc.network, tc.options...)
 
-			if tc.expectedErr {
-				if port != 0 {
-					t.Errorf("expected 0, got %d", port)
-				}
-				if err == nil {
-					t.Error("expected an error, got nil")
-				}
-			} else {
-				if port == 0 {
-					t.Error("expected a port, got 0")
-				}
-				if err != nil {
-					t.Errorf("expected no error, got %s", err)
-				}
+			isErrNil := err == nil
+			if tc.expectedErr == isErrNil {
+				t.Errorf("expected error is %t, got %v", tc.expectedErr, err)
+			}
+
+			noPortNumber := port == 0
+			if tc.expectedErr != noPortNumber {
+				t.Errorf("expected port is %t, got %d", !tc.expectedErr, port)
 			}
 		})
 	}

--- a/xtime/time_test.go
+++ b/xtime/time_test.go
@@ -93,7 +93,7 @@ func TestNowMilli(t *testing.T) {
 	time.Sleep(time.Millisecond)
 	after := time.Now()
 
-	if !got.After(before) || !after.After(got.T()) {
+	if got.Before(before) || got.After(after) {
 		t.Errorf("%s expected to be in range [%s, %s]", got, before, after)
 	}
 }

--- a/xtime/timestamp_test.go
+++ b/xtime/timestamp_test.go
@@ -92,7 +92,7 @@ func TestNowStampMilli(t *testing.T) {
 	time.Sleep(time.Millisecond)
 	after := time.Now()
 
-	if !got.After(before) || !after.After(got.T()) {
+	if got.Before(before) || got.After(after) {
 		t.Errorf("%s expected to be in range [%s, %s]", got, before, after)
 	}
 }


### PR DESCRIPTION
Add newly available linters
Removes deprecated linters
Amends code accordingly