### PR TITLE
ci(lint): upgrade golangci-lint to v1.55

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51
+          version: v1.55
   # tests
   test:
     needs: lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,9 +4,8 @@ linters-settings:
   errcheck:
     check-blank: true
     check-type-assertions: true
-  funlen:
-    lines: 100
-    statements: 50
+  exhaustive:
+    default-signifies-exhaustive: true
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -21,6 +20,9 @@ linters-settings:
     min-complexity: 15
   godot:
     capital: true
+  gofumpt:
+    module-path: github.com/jlourenc/xgo
+    extra-rules: true
   goheader:
     template: |-
       Copyright {{ YEAR }} Jérémy Lourenço. All rights reserved.
@@ -41,14 +43,15 @@ linters-settings:
       modules: []
       domains: []
   gosimple:
-    checks: [all]
+    checks: ['all']
     settings:
       shadow:
         strict: true
+  gosmopolitan:
+    allow-time-local: true
   govet:
     check-shadowing: true
-  lll:
-    line-length: 140
+    enable-all: true
   misspell:
     locale: US
   nolintlint:
@@ -56,10 +59,31 @@ linters-settings:
     require-specific: true
   prealloc:
     for-loops: true
+  revive:
+    enable-all-rules: true
+    rules:
+      - name: add-constant
+        disabled: true
+      - name: cognitive-complexity
+        disabled: true
+      - name: cyclomatic
+        disabled: true
+      - name: deep-exit
+        disabled: true
+      - name: flag-parameter
+        disabled: true
+      - name: function-length
+        arguments: [50,100]
+      - name: line-length-limit
+        arguments: [150]
+      - name: unhandled-error
+        arguments:
+          - 'fmt\.F?(P|p)rint(f|ln)?'
+          - 'strings\.Builder\.WriteString'
   staticcheck:
-    checks: [all]
+    checks: ['all']
   stylecheck:
-    checks: [all]
+    checks: ['all']
     http-status-code-whitelist: []
   tenv:
     all: true
@@ -73,8 +97,8 @@ linters-settings:
     time-month: true
     tls-signature-scheme: true
 linters:
-  disable-all: true
   enable:
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose
@@ -83,30 +107,33 @@ linters:
     - dogsled
     - dupl
     - durationcheck
-    - errcheck
     - execinquery
     - exhaustive
     - exportloopref
     - forbidigo
-    - funlen
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - goconst
     - gocritic
     - gocyclo
     - godot
     - godox
+    - gofumpt
     - goheader
     - goimports
     - gomnd
+    - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
-    - govet
-    - importas
-    - ineffassign
-    - lll
-    - maintidx
+    - gosmopolitan
+    - inamedparam
+    - interfacebloat
+    - loggercheck
+    - makezero
+    - mirror
     - misspell
+    - musttag
     - nakedret
     - nestif
     - nilerr
@@ -114,13 +141,17 @@ linters:
     - noctx
     - nolintlint
     - nosprintfhostport
+    - perfsprint
     - prealloc
     - predeclared
+    - protogetter
     - reassign
+    - revive
     - rowserrcheck
+    - sloglint
     - sqlclosecheck
-    - staticcheck
     - stylecheck
+    - tagalign
     - tagliatelle
     - tenv
     - testpackage
@@ -129,17 +160,17 @@ linters:
     - typecheck
     - unconvert
     - unparam
-    - unused
     - usestdlibvars
     - wastedassign
     - whitespace
+    - zerologlint
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
         - dupl
         - errcheck
-        - funlen
         - goconst
         - gomnd
+        - govet
         - lll

--- a/xerrors/errors.go
+++ b/xerrors/errors.go
@@ -29,7 +29,7 @@ func New(message string) error {
 // New also records a stack trace at the point it is called if enabled.
 //
 // It is the equivalent of fmt.Errorf.
-func Newf(format string, args ...interface{}) error {
+func Newf(format string, args ...any) error {
 	return &withStack{
 		error: fmt.Errorf(format, args...),
 		stack: callers(),

--- a/xerrors/errors_test.go
+++ b/xerrors/errors_test.go
@@ -7,7 +7,7 @@ package xerrors_test
 import (
 	"testing"
 
-	. "github.com/jlourenc/xgo/xerrors"
+	"github.com/jlourenc/xgo/xerrors"
 )
 
 func TestNew(t *testing.T) {
@@ -30,7 +30,7 @@ func TestNew(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := New(tc.message)
+			got := xerrors.New(tc.message)
 
 			if tc.expected != got.Error() {
 				t.Errorf("expected %s; got %s", tc.expected, got)
@@ -43,7 +43,7 @@ func TestNewf(t *testing.T) {
 	testCases := []struct {
 		name     string
 		format   string
-		args     []interface{}
+		args     []any
 		expected string
 	}{
 		{
@@ -55,14 +55,14 @@ func TestNewf(t *testing.T) {
 		{
 			name:     "non-empty format",
 			format:   "a %s message",
-			args:     []interface{}{"non-empty"},
+			args:     []any{"non-empty"},
 			expected: "a non-empty message",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Newf(tc.format, tc.args...)
+			got := xerrors.Newf(tc.format, tc.args...)
 
 			if tc.expected != got.Error() {
 				t.Errorf("expected %s; got %s", tc.expected, got)

--- a/xerrors/example_test.go
+++ b/xerrors/example_test.go
@@ -19,7 +19,7 @@ func ExampleAppend() {
 		if b < 0 {
 			errs = xerrors.Append(errs, xerrors.New("right operand is negative"))
 		}
-		return
+		return errs
 	}
 
 	var errs error

--- a/xerrors/slice.go
+++ b/xerrors/slice.go
@@ -138,7 +138,7 @@ func (e *withSlice) Unwrap() error {
 type chain []error
 
 // As implements errors.As by attempting to map to the current value.
-func (e chain) As(target interface{}) bool {
+func (e chain) As(target any) bool {
 	return As(e[0], target)
 }
 

--- a/xerrors/stack_test.go
+++ b/xerrors/stack_test.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"testing"
 
-	. "github.com/jlourenc/xgo/xerrors"
+	"github.com/jlourenc/xgo/xerrors"
 )
 
 type (
@@ -18,9 +18,9 @@ type (
 	unstackError struct{}
 )
 
-func (unstackError) Error() string        { return "unstack error" }
-func (stackError) Error() string          { return "stack error" }
-func (stackError) StackTrace() StackTrace { return []Frame{0, 1, 2, 3} }
+func (unstackError) Error() string                { return "unstack error" }
+func (stackError) Error() string                  { return "stack error" }
+func (stackError) StackTrace() xerrors.StackTrace { return []xerrors.Frame{0, 1, 2, 3} }
 
 func TestWithStack(t *testing.T) {
 	testCases := []struct {
@@ -62,7 +62,7 @@ func TestWithStack(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := WithStack(tc.err)
+			got := xerrors.WithStack(tc.err)
 
 			tc.assert(t, got)
 		})
@@ -137,10 +137,10 @@ func TestWithStack_Format(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			EnableStackTrace(tc.enableStackTrace)
-			defer EnableStackTrace(false)
+			xerrors.EnableStackTrace(tc.enableStackTrace)
+			defer xerrors.EnableStackTrace(false)
 
-			got := fmt.Sprintf(tc.format, WithStack(tc.err))
+			got := fmt.Sprintf(tc.format, xerrors.WithStack(tc.err))
 
 			re, err := regexp.Compile(tc.expected)
 			if err != nil {
@@ -161,7 +161,7 @@ func TestWithStack_Unwrap(t *testing.T) {
 	}{
 		{
 			name:     "unwrap",
-			err:      WithStack(&unstackError{}),
+			err:      xerrors.WithStack(&unstackError{}),
 			expected: &unstackError{},
 		},
 	}

--- a/xerrors/stackframe_test.go
+++ b/xerrors/stackframe_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	. "github.com/jlourenc/xgo/xerrors"
+	"github.com/jlourenc/xgo/xerrors"
 )
 
 func TestFrame_Format(t *testing.T) {
@@ -20,55 +20,55 @@ func TestFrame_Format(t *testing.T) {
 	testCases := []struct {
 		name     string
 		format   string
-		frame    Frame
+		frame    xerrors.Frame
 		expected string
 	}{
 		{
 			name:     "source file",
 			format:   "%s",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^stackframe_test.go$`,
 		},
 		{
 			name:     "source file plus extra",
 			format:   "%+s",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^github\.com\/jlourenc\/xgo\/xerrors_test\.TestFrame_Format\n\t.*\/xgo\/xerrors\/stackframe_test\.go$`,
 		},
 		{
 			name:     "source line",
 			format:   "%d",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^18$`,
 		},
 		{
 			name:     "function name",
 			format:   "%n",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^TestFrame_Format$`,
 		},
 		{
 			name:     "source file and line",
 			format:   "%v",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^stackframe_test\.go:18$`,
 		},
 		{
 			name:     "source file and line plus extra of unknown frame",
 			format:   "%+v",
-			frame:    Frame(0),
+			frame:    xerrors.Frame(0),
 			expected: `^unknown\n\tunknown:0$`,
 		},
 		{
 			name:     "source file and line plus extra",
 			format:   "%+v",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^github.com\/jlourenc\/xgo\/xerrors_test\.TestFrame_Format\n\t.*\/xgo\/xerrors\/stackframe_test\.go:18$`,
 		},
 		{
 			name:     "unsupported format",
 			format:   "%t",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^$`,
 		},
 	}
@@ -94,17 +94,17 @@ func TestFrame_MarshalText(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		frame    Frame
+		frame    xerrors.Frame
 		expected string
 	}{
 		{
 			name:     "known frame",
-			frame:    Frame(pcs[0]),
+			frame:    xerrors.Frame(pcs[0]),
 			expected: `^github.com\/jlourenc\/xgo\/xerrors_test\.TestFrame_MarshalText .*\/xgo\/xerrors\/stackframe_test\.go:93$`,
 		},
 		{
 			name:     "unknown frame",
-			frame:    Frame(0),
+			frame:    xerrors.Frame(0),
 			expected: `^unknown$`,
 		},
 	}
@@ -112,7 +112,6 @@ func TestFrame_MarshalText(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := tc.frame.MarshalText()
-
 			if err != nil {
 				t.Fatalf("error is not expected")
 			}
@@ -121,7 +120,7 @@ func TestFrame_MarshalText(t *testing.T) {
 			if err != nil {
 				t.Fatalf("invalid regex: %s", tc.expected)
 			}
-			if !re.MatchString(string(got)) {
+			if !re.Match(got) {
 				t.Errorf("expected pattern %s, got %s", tc.expected, got)
 			}
 		})
@@ -135,32 +134,32 @@ func TestStackTrace_Format(t *testing.T) {
 	testCases := []struct {
 		name       string
 		format     string
-		stackTrace StackTrace
+		stackTrace xerrors.StackTrace
 		expected   string
 	}{
 		{
 			name:       "lists source files",
 			format:     "%s",
-			stackTrace: StackTrace{Frame(pcs[0]), Frame(pcs[1])},
+			stackTrace: xerrors.StackTrace{xerrors.Frame(pcs[0]), xerrors.Frame(pcs[1])},
 			expected:   `^\[stackframe_test\.go testing\.go\]$`,
 		},
 		{
 			name:       "lists source files and line numbers",
 			format:     "%v",
-			stackTrace: StackTrace{Frame(pcs[0])},
-			expected:   `^\[stackframe_test\.go:133\]$`,
+			stackTrace: xerrors.StackTrace{xerrors.Frame(pcs[0])},
+			expected:   `^\[stackframe_test\.go:132\]$`,
 		},
 		{
 			name:       "lists source files, line numbers and function names",
 			format:     "%+v",
-			stackTrace: StackTrace{Frame(pcs[0])},
-			expected:   `^\ngithub\.com\/jlourenc\/xgo\/xerrors_test\.TestStackTrace_Format\n\t.*\/xgo\/xerrors\/stackframe_test\.go:133$`,
+			stackTrace: xerrors.StackTrace{xerrors.Frame(pcs[0])},
+			expected:   `^\ngithub\.com\/jlourenc\/xgo\/xerrors_test\.TestStackTrace_Format\n\t.*\/xgo\/xerrors\/stackframe_test\.go:132$`,
 		},
 		{
 			name:       "source file and line plus extra",
 			format:     "%#v",
-			stackTrace: StackTrace{Frame(pcs[0])},
-			expected:   `^\[\]xerrors\.Frame\{stackframe_test\.go:133\}$`,
+			stackTrace: xerrors.StackTrace{xerrors.Frame(pcs[0])},
+			expected:   `^\[\]xerrors\.Frame\{stackframe_test\.go:132\}$`,
 		},
 	}
 

--- a/xerrors/wrap.go
+++ b/xerrors/wrap.go
@@ -16,7 +16,7 @@ import (
 // repeatedly calling Unwrap.
 //
 // An error matches target if the error's concrete value is assignable to the value
-// pointed to by target, or if the error has a method As(interface{}) bool such that
+// pointed to by target, or if the error has a method As(any) bool such that
 // As(target) returns true. In the latter case, the As method is responsible for
 // setting target.
 //
@@ -27,7 +27,7 @@ import (
 // error, or to any interface type.
 //
 // It is the drop-in replacement for errors.As.
-func As(err error, target interface{}) bool {
+func As(err error, target any) bool {
 	return errors.As(err, target)
 }
 
@@ -85,7 +85,7 @@ func Wrap(err error, message string) error {
 // Wrapf returns an error annotating err with the format specifier and a stack trace,
 // if enabled and err does not already contain one, at the point Wrap is called.
 // If err is nil, Wrap returns nil.
-func Wrapf(err error, format string, args ...interface{}) error {
+func Wrapf(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}
@@ -104,8 +104,8 @@ func Wrapf(err error, format string, args ...interface{}) error {
 }
 
 type withWrap struct {
-	msg string
 	err error
+	msg string
 }
 
 // Error makes withWrap implement the error interface.

--- a/xio/io_test.go
+++ b/xio/io_test.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"testing"
 
-	. "github.com/jlourenc/xgo/xio"
+	"github.com/jlourenc/xgo/xio"
 )
 
 func TestDrainClose(t *testing.T) {
@@ -47,7 +47,7 @@ func TestDrainClose(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DrainClose(tc.rc)
+			got := xio.DrainClose(tc.rc)
 
 			if tc.expected != got {
 				t.Errorf("expected %s; got %s", tc.expected, got)
@@ -89,7 +89,7 @@ func TestDuplicateReader(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r1, r2, err := DuplicateReader(tc.r)
+			r1, r2, err := xio.DuplicateReader(tc.r)
 
 			if r1 != nil {
 				b1, _ := io.ReadAll(r1)
@@ -160,7 +160,7 @@ func TestDuplicateReadCloser(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rc1, rc2, err := DuplicateReadCloser(tc.rc)
+			rc1, rc2, err := xio.DuplicateReadCloser(tc.rc)
 
 			if rc1 != nil {
 				b1, _ := io.ReadAll(rc1)
@@ -193,7 +193,7 @@ func TestDuplicateReadCloser(t *testing.T) {
 
 type errClose struct{}
 
-func (errClose) Read(p []byte) (n int, err error) {
+func (errClose) Read([]byte) (n int, err error) {
 	return 0, io.EOF
 }
 
@@ -203,7 +203,7 @@ func (errClose) Close() error {
 
 type errRead struct{}
 
-func (errRead) Read(p []byte) (n int, err error) {
+func (errRead) Read([]byte) (n int, err error) {
 	return 0, io.ErrNoProgress
 }
 
@@ -213,7 +213,7 @@ func (errRead) Close() error {
 
 type errReadClose struct{}
 
-func (errReadClose) Read(p []byte) (n int, err error) {
+func (errReadClose) Read([]byte) (n int, err error) {
 	return 0, io.ErrNoProgress
 }
 

--- a/xmath/dim_test.go
+++ b/xmath/dim_test.go
@@ -7,7 +7,7 @@ package xmath_test
 import (
 	"testing"
 
-	. "github.com/jlourenc/xgo/xmath"
+	"github.com/jlourenc/xgo/xmath"
 )
 
 func TestDimInt(t *testing.T) {
@@ -51,7 +51,7 @@ func TestDimInt(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DimInt(tc.x, tc.y)
+			got := xmath.DimInt(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -101,7 +101,7 @@ func TestDimInt64(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DimInt64(tc.x, tc.y)
+			got := xmath.DimInt64(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -139,7 +139,7 @@ func TestDimUint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DimUint(tc.x, tc.y)
+			got := xmath.DimUint(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -177,7 +177,7 @@ func TestDimUint64(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DimUint64(tc.x, tc.y)
+			got := xmath.DimUint64(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -215,7 +215,7 @@ func TestMaxInt(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MaxInt(tc.x, tc.y)
+			got := xmath.MaxInt(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -253,7 +253,7 @@ func TestMaxInt64(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MaxInt64(tc.x, tc.y)
+			got := xmath.MaxInt64(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -291,7 +291,7 @@ func TestMaxUint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MaxUint(tc.x, tc.y)
+			got := xmath.MaxUint(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -329,7 +329,7 @@ func TestMaxUint64(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MaxUint64(tc.x, tc.y)
+			got := xmath.MaxUint64(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -367,7 +367,7 @@ func TestMinInt(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MinInt(tc.x, tc.y)
+			got := xmath.MinInt(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -405,7 +405,7 @@ func TestMinInt64(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MinInt64(tc.x, tc.y)
+			got := xmath.MinInt64(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -443,7 +443,7 @@ func TestMinUint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MinUint(tc.x, tc.y)
+			got := xmath.MinUint(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)
@@ -481,7 +481,7 @@ func TestMinUint64(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := MinUint64(tc.x, tc.y)
+			got := xmath.MinUint64(tc.x, tc.y)
 
 			if got != tc.expected {
 				t.Errorf("expected %d; got %d", tc.expected, got)

--- a/xnet/dial.go
+++ b/xnet/dial.go
@@ -82,7 +82,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 type (
 	// DialOption configures how connections are made.
 	DialOption interface {
-		apply(*Dialer)
+		apply(d *Dialer)
 	}
 
 	funcDialOption struct {
@@ -139,7 +139,7 @@ func DialWriteTimeout(timeout time.Duration) DialOption {
 type (
 	// ListenConfigOption is an option to configure  anet.ListenConfig.
 	ListenConfigOption interface {
-		apply(*net.ListenConfig)
+		apply(lc *net.ListenConfig)
 	}
 
 	funcListenConfigOption struct {

--- a/xnet/port_test.go
+++ b/xnet/port_test.go
@@ -11,58 +11,58 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/jlourenc/xgo/xnet"
+	"github.com/jlourenc/xgo/xnet"
 )
 
 func TestFreePort(t *testing.T) {
 	testCases := []struct {
 		name        string
-		options     []ListenConfigOption
+		options     []xnet.ListenConfigOption
 		network     string
 		expectedErr bool
 	}{
 		{
 			name:        "unsupported network",
-			network:     NetworkUnix,
+			network:     xnet.NetworkUnix,
 			expectedErr: true,
 		},
 		{
 			name:        "tcp network - success",
-			network:     NetworkTCP,
+			network:     xnet.NetworkTCP,
 			expectedErr: false,
 		},
 		{
 			name:        "udp network - success",
-			network:     NetworkUDP,
+			network:     xnet.NetworkUDP,
 			expectedErr: false,
 		},
 		{
 			name: "tcp network - failure",
-			options: []ListenConfigOption{
-				ListenConfigControl(func(network, address string, c syscall.RawConn) error {
+			options: []xnet.ListenConfigOption{
+				xnet.ListenConfigControl(func(network, address string, c syscall.RawConn) error {
 					return errors.New("always error")
 				}),
-				ListenConfigKeepAlive(time.Second),
+				xnet.ListenConfigKeepAlive(time.Second),
 			},
-			network:     NetworkTCP,
+			network:     xnet.NetworkTCP,
 			expectedErr: true,
 		},
 		{
 			name: "udp network - failure",
-			options: []ListenConfigOption{
-				ListenConfigControl(func(network, address string, c syscall.RawConn) error {
+			options: []xnet.ListenConfigOption{
+				xnet.ListenConfigControl(func(network, address string, c syscall.RawConn) error {
 					return errors.New("always error")
 				}),
-				ListenConfigKeepAlive(time.Second),
+				xnet.ListenConfigKeepAlive(time.Second),
 			},
-			network:     NetworkUDP,
+			network:     xnet.NetworkUDP,
 			expectedErr: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			port, err := FreePort(context.Background(), tc.network, tc.options...)
+			port, err := xnet.FreePort(context.Background(), tc.network, tc.options...)
 
 			isErrNil := err == nil
 			if tc.expectedErr == isErrNil {
@@ -131,7 +131,7 @@ func TestParsePort(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			port, err := ParsePort(tc.port, tc.allowZero)
+			port, err := xnet.ParsePort(tc.port, tc.allowZero)
 
 			if tc.expectedPort != port {
 				t.Errorf("expected %d, got %d", tc.expectedPort, port)

--- a/xnet/xhttp/header.go
+++ b/xnet/xhttp/header.go
@@ -252,9 +252,7 @@ const (
 	CacheControlStaleWhileRevalidate = "stale-while-revalidate"
 )
 
-var (
-	errHeaderNoDate = errors.New("no date header")
-)
+var errHeaderNoDate = errors.New("no date header")
 
 // HeaderExist returns whether the key exists in headers.
 func HeaderExist(headers http.Header, key string) bool {
@@ -294,7 +292,7 @@ func HeaderValues(headers http.Header, key string) (headerValues []string) {
 		}
 		headerValues = append(headerValues, fields...)
 	}
-	return
+	return headerValues
 }
 
 // ParseHeaderDate parses the Date header and returns its value as a time.Time if valid.

--- a/xnet/xhttp/header_test.go
+++ b/xnet/xhttp/header_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/jlourenc/xgo/xnet/xhttp"
+	"github.com/jlourenc/xgo/xnet/xhttp"
 )
 
 func TestHeaderExist(t *testing.T) {
@@ -47,7 +47,7 @@ func TestHeaderExist(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := HeaderExist(tc.headers, tc.key)
+			got := xhttp.HeaderExist(tc.headers, tc.key)
 
 			if tc.expected != got {
 				t.Errorf("expected %v; got %v", tc.expected, got)
@@ -118,7 +118,7 @@ func TestHeaderKeyValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := HeaderKeyValues(tc.headers, tc.key)
+			got := xhttp.HeaderKeyValues(tc.headers, tc.key)
 
 			if len(tc.expected) != len(got) {
 				t.Fatalf("expected %v; got %v", tc.expected, got)
@@ -185,7 +185,7 @@ func TestHeaderValues(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := HeaderValues(tc.headers, tc.key)
+			got := xhttp.HeaderValues(tc.headers, tc.key)
 
 			if len(tc.expected) != len(got) {
 				t.Fatalf("expected %v; got %v", tc.expected, got)
@@ -216,7 +216,7 @@ func TestParseHeaderDate(t *testing.T) {
 		{
 			name: "empty",
 			headers: http.Header{
-				HeaderDate: {""},
+				xhttp.HeaderDate: {""},
 			},
 			expectedTime: time.Time{},
 			expectedErr:  true,
@@ -224,7 +224,7 @@ func TestParseHeaderDate(t *testing.T) {
 		{
 			name: "invalid date",
 			headers: http.Header{
-				HeaderDate: {"invalid"},
+				xhttp.HeaderDate: {"invalid"},
 			},
 			expectedTime: time.Time{},
 			expectedErr:  true,
@@ -232,7 +232,7 @@ func TestParseHeaderDate(t *testing.T) {
 		{
 			name: "invalid format",
 			headers: http.Header{
-				HeaderDate: {"1994-11-06T08:49:37Z00:00"},
+				xhttp.HeaderDate: {"1994-11-06T08:49:37Z00:00"},
 			},
 			expectedTime: time.Time{},
 			expectedErr:  true,
@@ -240,7 +240,7 @@ func TestParseHeaderDate(t *testing.T) {
 		{
 			name: "RFC1123 format",
 			headers: http.Header{
-				HeaderDate: {"Sun, 10 Jul 2016 21:12:00.499 GMT"},
+				xhttp.HeaderDate: {"Sun, 10 Jul 2016 21:12:00.499 GMT"},
 			},
 			expectedTime: time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.UTC),
 			expectedErr:  false,
@@ -248,7 +248,7 @@ func TestParseHeaderDate(t *testing.T) {
 		{
 			name: "RFC850 format",
 			headers: http.Header{
-				HeaderDate: {"Sunday, 10-Jul-16 21:12:00 GMT"},
+				xhttp.HeaderDate: {"Sunday, 10-Jul-16 21:12:00 GMT"},
 			},
 			expectedTime: time.Date(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 			expectedErr:  false,
@@ -256,7 +256,7 @@ func TestParseHeaderDate(t *testing.T) {
 		{
 			name: "ANSIC format",
 			headers: http.Header{
-				HeaderDate: {"Sun Jul 10 21:12:00 2016"},
+				xhttp.HeaderDate: {"Sun Jul 10 21:12:00 2016"},
 			},
 			expectedTime: time.Date(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 			expectedErr:  false,
@@ -265,7 +265,7 @@ func TestParseHeaderDate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			d, err := ParseHeaderDate(tc.headers)
+			d, err := xhttp.ParseHeaderDate(tc.headers)
 
 			if tc.expectedErr && err == nil {
 				t.Error("error expected, got nil")
@@ -357,7 +357,7 @@ func TestReplaceHeader(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ReplaceHeader(tc.headers, tc.prefix, tc.key, tc.values...)
+			xhttp.ReplaceHeader(tc.headers, tc.prefix, tc.key, tc.values...)
 
 			if len(tc.expected) != len(tc.headers) {
 				t.Fatalf("expected %v; got %v", tc.expected, tc.headers)

--- a/xnet/xurl/url_test.go
+++ b/xnet/xurl/url_test.go
@@ -7,7 +7,7 @@ package xurl_test
 import (
 	"testing"
 
-	. "github.com/jlourenc/xgo/xnet/xurl"
+	"github.com/jlourenc/xgo/xnet/xurl"
 )
 
 func TestJoinBasePath(t *testing.T) {
@@ -45,7 +45,7 @@ func TestJoinBasePath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := JoinBasePath(tc.base, tc.elems...)
+			got := xurl.JoinBasePath(tc.base, tc.elems...)
 
 			if tc.expected != got {
 				t.Errorf("expected %v; got %v", tc.expected, got)
@@ -84,7 +84,7 @@ func TestJoinPath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := JoinPath(tc.elems...)
+			got := xurl.JoinPath(tc.elems...)
 
 			if tc.expected != got {
 				t.Errorf("expected %v; got %v", tc.expected, got)

--- a/xsort/exist_test.go
+++ b/xsort/exist_test.go
@@ -7,7 +7,7 @@ package xsort_test
 import (
 	"testing"
 
-	. "github.com/jlourenc/xgo/xsort"
+	"github.com/jlourenc/xgo/xsort"
 )
 
 func TestExist(t *testing.T) {
@@ -94,7 +94,7 @@ func TestExist(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Exist(tc.n, tc.cmp)
+			got := xsort.Exist(tc.n, tc.cmp)
 
 			if got != tc.expected {
 				t.Errorf("expected %t; got %t", tc.expected, got)
@@ -132,7 +132,7 @@ func TestExistInts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ExistInts(tc.a, tc.x)
+			got := xsort.ExistInts(tc.a, tc.x)
 
 			if got != tc.expected {
 				t.Errorf("expected %t; got %t", tc.expected, got)
@@ -170,7 +170,7 @@ func TestExistFloat64s(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ExistFloat64s(tc.a, tc.x)
+			got := xsort.ExistFloat64s(tc.a, tc.x)
 
 			if got != tc.expected {
 				t.Errorf("expected %t; got %t", tc.expected, got)
@@ -208,7 +208,7 @@ func TestExistStrings(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ExistStrings(tc.a, tc.x)
+			got := xsort.ExistStrings(tc.a, tc.x)
 
 			if got != tc.expected {
 				t.Errorf("expected %t; got %t", tc.expected, got)

--- a/xtime/format_test.go
+++ b/xtime/format_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/jlourenc/xgo/xtime"
+	"github.com/jlourenc/xgo/xtime"
 )
 
 func TestLayouts(t *testing.T) {
@@ -22,7 +22,7 @@ func TestLayouts(t *testing.T) {
 	}{
 		{
 			name:   "RFC3339Milli",
-			layout: RFC3339Milli,
+			layout: xtime.RFC3339Milli,
 			value:  "2016-07-10T21:12:00.499Z",
 			offset: 999999 * time.Nanosecond,
 		},
@@ -38,7 +38,7 @@ func TestLayouts(t *testing.T) {
 			p, err := time.Parse(tc.layout, tc.value)
 			if err != nil {
 				t.Errorf("no error expected; got %s", err)
-			} else if p.Add(tc.offset) != x {
+			} else if !p.Add(tc.offset).Equal(x) {
 				t.Errorf("expected %v; got %v", x, p.Add(tc.offset))
 			}
 		})
@@ -50,26 +50,26 @@ func TestParseMilli(t *testing.T) {
 		name         string
 		layout       string
 		value        string
-		expectedTime TimeMilli
+		expectedTime xtime.TimeMilli
 		expectedErr  bool
 	}{
 		{
 			name:        "invalid value",
-			layout:      RFC3339Milli,
+			layout:      xtime.RFC3339Milli,
 			value:       "invalid",
 			expectedErr: true,
 		},
 		{
 			name:         "RFC3339Milli",
-			layout:       RFC3339Milli,
+			layout:       xtime.RFC3339Milli,
 			value:        "2016-07-10T21:12:00.499Z",
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			x, err := ParseMilli(tc.layout, tc.value)
+			x, err := xtime.ParseMilli(tc.layout, tc.value)
 
 			if tc.expectedErr && err == nil {
 				t.Error("error expected; got nil")
@@ -91,34 +91,34 @@ func TestParseMilliInLocation(t *testing.T) {
 		layout       string
 		value        string
 		location     *time.Location
-		expectedTime TimeMilli
+		expectedTime xtime.TimeMilli
 		expectedErr  bool
 	}{
 		{
 			name:        "invalid value",
-			layout:      RFC3339Milli,
+			layout:      xtime.RFC3339Milli,
 			value:       "invalid",
 			expectedErr: true,
 		},
 		{
 			name:         "RFC3339Milli - nil location",
-			layout:       RFC3339Milli,
+			layout:       xtime.RFC3339Milli,
 			value:        "2016-07-10T21:12:00.499Z",
 			location:     nil,
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:         "RFC3339Milli - CET",
-			layout:       RFC3339Milli,
+			layout:       xtime.RFC3339Milli,
 			value:        "2016-07-10T21:12:00.499+02:00",
 			location:     time.FixedZone("CET", 2*60*60),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			x, err := ParseMilliInLocation(tc.layout, tc.value, tc.location)
+			x, err := xtime.ParseMilliInLocation(tc.layout, tc.value, tc.location)
 
 			if tc.expectedErr && err == nil {
 				t.Error("error expected; got nil")
@@ -139,26 +139,26 @@ func TestParseStampMilli(t *testing.T) {
 		name         string
 		layout       string
 		value        string
-		expectedTime TimestampMilli
+		expectedTime xtime.TimestampMilli
 		expectedErr  bool
 	}{
 		{
 			name:        "invalid value",
-			layout:      RFC3339Milli,
+			layout:      xtime.RFC3339Milli,
 			value:       "invalid",
 			expectedErr: true,
 		},
 		{
 			name:         "RFC3339Milli",
-			layout:       RFC3339Milli,
+			layout:       xtime.RFC3339Milli,
 			value:        "2016-07-10T21:12:00.499Z",
-			expectedTime: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTime: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			x, err := ParseStampMilli(tc.layout, tc.value)
+			x, err := xtime.ParseStampMilli(tc.layout, tc.value)
 
 			if tc.expectedErr && err == nil {
 				t.Error("error expected; got nil")
@@ -180,34 +180,34 @@ func TestParseStampMilliInLocation(t *testing.T) {
 		layout       string
 		value        string
 		location     *time.Location
-		expectedTime TimestampMilli
+		expectedTime xtime.TimestampMilli
 		expectedErr  bool
 	}{
 		{
 			name:        "invalid value",
-			layout:      RFC3339Milli,
+			layout:      xtime.RFC3339Milli,
 			value:       "invalid",
 			expectedErr: true,
 		},
 		{
 			name:         "RFC3339Milli - nil location",
-			layout:       RFC3339Milli,
+			layout:       xtime.RFC3339Milli,
 			value:        "2016-07-10T21:12:00.499Z",
 			location:     nil,
-			expectedTime: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTime: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:         "RFC3339Milli - CET",
-			layout:       RFC3339Milli,
+			layout:       xtime.RFC3339Milli,
 			value:        "2016-07-10T21:12:00.499+02:00",
 			location:     time.FixedZone("CET", 2*60*60),
-			expectedTime: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expectedTime: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			x, err := ParseStampMilliInLocation(tc.layout, tc.value, tc.location)
+			x, err := xtime.ParseStampMilliInLocation(tc.layout, tc.value, tc.location)
 
 			if tc.expectedErr && err == nil {
 				t.Error("error expected; got nil")

--- a/xtime/time_test.go
+++ b/xtime/time_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/jlourenc/xgo/xtime"
+	"github.com/jlourenc/xgo/xtime"
 )
 
 func TestDateMilli(t *testing.T) {
@@ -78,7 +78,7 @@ func TestDateMilli(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DateMilli(tc.year, tc.month, tc.day, tc.hour, tc.min, tc.sec, tc.msec, tc.loc)
+			got := xtime.DateMilli(tc.year, tc.month, tc.day, tc.hour, tc.min, tc.sec, tc.msec, tc.loc)
 			if !tc.expected.Equal(got.T()) {
 				t.Errorf("expected %s; got %s", tc.expected, got)
 			}
@@ -89,7 +89,7 @@ func TestDateMilli(t *testing.T) {
 func TestNowMilli(t *testing.T) {
 	before := time.Now()
 	time.Sleep(time.Millisecond)
-	got := NowMilli()
+	got := xtime.NowMilli()
 	time.Sleep(time.Millisecond)
 	after := time.Now()
 
@@ -100,7 +100,7 @@ func TestNowMilli(t *testing.T) {
 
 func TestToMilli(t *testing.T) {
 	expected := time.Now()
-	got := ToMilli(expected)
+	got := xtime.ToMilli(expected)
 
 	if !got.Equal(expected) {
 		t.Errorf("expected %s; got %s", expected, got)
@@ -136,7 +136,7 @@ func TestUnixMilli(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := UnixMilli(tc.sec, tc.msec)
+			got := xtime.UnixMilli(tc.sec, tc.msec)
 			if !tc.expected.Equal(got.T()) {
 				t.Errorf("expected %s; got %s", tc.expected, got)
 			}
@@ -147,27 +147,27 @@ func TestUnixMilli(t *testing.T) {
 func TestTimeMilli_Add(t *testing.T) {
 	testCases := []struct {
 		name     string
-		time     TimeMilli
+		time     xtime.TimeMilli
 		duration time.Duration
-		expected TimeMilli
+		expected xtime.TimeMilli
 	}{
 		{
 			name:     "zero duration",
-			time:     UnixMilli(1468181520, 499),
+			time:     xtime.UnixMilli(1468181520, 499),
 			duration: 0,
-			expected: UnixMilli(1468181520, 499),
+			expected: xtime.UnixMilli(1468181520, 499),
 		},
 		{
 			name:     "positive duration",
-			time:     UnixMilli(1468181520, 499),
+			time:     xtime.UnixMilli(1468181520, 499),
 			duration: 20 * time.Second,
-			expected: UnixMilli(1468181540, 499),
+			expected: xtime.UnixMilli(1468181540, 499),
 		},
 		{
 			name:     "negative duration",
-			time:     UnixMilli(1468181520, 499),
+			time:     xtime.UnixMilli(1468181520, 499),
 			duration: -20 * time.Second,
-			expected: UnixMilli(1468181500, 499),
+			expected: xtime.UnixMilli(1468181500, 499),
 		},
 	}
 
@@ -184,35 +184,35 @@ func TestTimeMilli_Add(t *testing.T) {
 func TestTimeMilli_AddDate(t *testing.T) {
 	testCases := []struct {
 		name     string
-		time     TimeMilli
+		time     xtime.TimeMilli
 		years    int
 		months   int
 		days     int
-		expected TimeMilli
+		expected xtime.TimeMilli
 	}{
 		{
 			name:     "zero values",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			years:    0,
 			months:   0,
 			days:     0,
-			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:     "no overflow values",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			years:    3,
 			months:   2,
 			days:     1,
-			expected: DateMilli(2019, time.September, 11, 21, 12, 0, 499, time.UTC),
+			expected: xtime.DateMilli(2019, time.September, 11, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:     "with overflow values",
-			time:     DateMilli(2016, time.December, 31, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.December, 31, 21, 12, 0, 499, time.UTC),
 			years:    1,
 			months:   1,
 			days:     1,
-			expected: DateMilli(2018, time.February, 1, 21, 12, 0, 499, time.UTC),
+			expected: xtime.DateMilli(2018, time.February, 1, 21, 12, 0, 499, time.UTC),
 		},
 	}
 
@@ -229,21 +229,21 @@ func TestTimeMilli_AddDate(t *testing.T) {
 func TestTimeMilli_In(t *testing.T) {
 	testCases := []struct {
 		name     string
-		time     TimeMilli
+		time     xtime.TimeMilli
 		location *time.Location
-		expected TimeMilli
+		expected xtime.TimeMilli
 	}{
 		{
 			name:     "UTC to UTC",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			location: time.UTC,
-			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:     "UTC to CET",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			location: time.FixedZone("CET", 2*60*60),
-			expected: DateMilli(2016, time.July, 10, 23, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expected: xtime.DateMilli(2016, time.July, 10, 23, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 	}
 
@@ -261,18 +261,18 @@ func TestTimeMilli_Local(t *testing.T) {
 	_, localOffset := time.Now().Local().Zone()
 	testCases := []struct {
 		name     string
-		time     TimeMilli
-		expected TimeMilli
+		time     xtime.TimeMilli
+		expected xtime.TimeMilli
 	}{
 		{
 			name:     "from UTC",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
-			expected: DateMilli(2016, time.July, 10, 21, 12, localOffset, 499, time.FixedZone("local", localOffset)),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, localOffset, 499, time.FixedZone("local", localOffset)),
 		},
 		{
 			name:     "from Local",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
-			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
 		},
 	}
 
@@ -289,25 +289,25 @@ func TestTimeMilli_Local(t *testing.T) {
 func TestTimeMilli_MarshalJSON(t *testing.T) {
 	testCases := []struct {
 		name          string
-		time          TimeMilli
+		time          xtime.TimeMilli
 		expectedBytes []byte
 		expectedErr   error
 	}{
 		{
 			name:          "invalid year",
-			time:          DateMilli(10001, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:          xtime.DateMilli(10001, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedBytes: nil,
 			expectedErr:   errors.New("TimeMilli.MarshalJSON: year outside of range [0,9999]"),
 		},
 		{
 			name:          "UTC - with msec",
-			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:          xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedBytes: []byte(`"2016-07-10T21:12:00.499Z"`),
 			expectedErr:   nil,
 		},
 		{
 			name:          "zone info - no msec",
-			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			time:          xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 			expectedBytes: []byte(`"2016-07-10T21:12:00+02:00"`),
 			expectedErr:   nil,
 		},
@@ -332,25 +332,25 @@ func TestTimeMilli_MarshalJSON(t *testing.T) {
 func TestTimeMilli_MarshalText(t *testing.T) {
 	testCases := []struct {
 		name          string
-		time          TimeMilli
+		time          xtime.TimeMilli
 		expectedBytes []byte
 		expectedErr   error
 	}{
 		{
 			name:          "invalid year",
-			time:          DateMilli(10001, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:          xtime.DateMilli(10001, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedBytes: nil,
 			expectedErr:   errors.New("TimeMilli.MarshalText: year outside of range [0,9999]"),
 		},
 		{
 			name:          "UTC - with msec",
-			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:          xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedBytes: []byte(`2016-07-10T21:12:00.499Z`),
 			expectedErr:   nil,
 		},
 		{
 			name:          "zone info - no msec",
-			time:          DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			time:          xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 			expectedBytes: []byte(`2016-07-10T21:12:00+02:00`),
 			expectedErr:   nil,
 		},
@@ -375,17 +375,17 @@ func TestTimeMilli_MarshalText(t *testing.T) {
 func TestTimeMilli_Millisecond(t *testing.T) {
 	testCases := []struct {
 		name     string
-		time     TimeMilli
+		time     xtime.TimeMilli
 		expected int
 	}{
 		{
 			name:     "no msec",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 			expected: 0,
 		},
 		{
 			name:     "with msec",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expected: 499,
 		},
 	}
@@ -403,21 +403,21 @@ func TestTimeMilli_Millisecond(t *testing.T) {
 func TestTimeMilli_Round(t *testing.T) {
 	testCases := []struct {
 		name     string
-		time     TimeMilli
+		time     xtime.TimeMilli
 		duration time.Duration
-		expected TimeMilli
+		expected xtime.TimeMilli
 	}{
 		{
 			name:     "nearest second",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
 			duration: 2 * time.Second,
-			expected: DateMilli(2016, time.July, 10, 21, 12, 2, 0, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, 2, 0, time.UTC),
 		},
 		{
 			name:     "nearest hour",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			duration: time.Hour,
-			expected: DateMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
 		},
 	}
 
@@ -432,7 +432,7 @@ func TestTimeMilli_Round(t *testing.T) {
 }
 
 func TestTimeMilli_T(t *testing.T) {
-	x := DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC)
+	x := xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC)
 	expected := time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.UTC)
 	got := x.T()
 
@@ -444,21 +444,21 @@ func TestTimeMilli_T(t *testing.T) {
 func TestTimeMilli_Truncate(t *testing.T) {
 	testCases := []struct {
 		name     string
-		time     TimeMilli
+		time     xtime.TimeMilli
 		duration time.Duration
-		expected TimeMilli
+		expected xtime.TimeMilli
 	}{
 		{
 			name:     "rounding down to a multiple of 2 seconds",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
 			duration: 2 * time.Second,
-			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 		},
 		{
 			name:     "rounding down to nearest hour",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			duration: time.Hour,
-			expected: DateMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
 		},
 	}
 
@@ -476,18 +476,18 @@ func TestTimeMilli_UTC(t *testing.T) {
 	_, localOffset := time.Now().Local().Zone()
 	testCases := []struct {
 		name     string
-		time     TimeMilli
-		expected TimeMilli
+		time     xtime.TimeMilli
+		expected xtime.TimeMilli
 	}{
 		{
 			name:     "from UTC",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
-			expected: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:     "from Local",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("local", localOffset)),
-			expected: DateMilli(2016, time.July, 10, 21, 12, -localOffset, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("local", localOffset)),
+			expected: xtime.DateMilli(2016, time.July, 10, 21, 12, -localOffset, 499, time.UTC),
 		},
 	}
 
@@ -504,17 +504,17 @@ func TestTimeMilli_UTC(t *testing.T) {
 func TestTimeMilli_UnixMilli(t *testing.T) {
 	testCases := []struct {
 		name     string
-		time     TimeMilli
+		time     xtime.TimeMilli
 		expected int64
 	}{
 		{
 			name:     "no msec",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 			expected: 1468185120000,
 		},
 		{
 			name:     "with msec",
-			time:     DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			time:     xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expected: 1468185120499,
 		},
 	}
@@ -533,40 +533,40 @@ func TestTimeMilli_UnmarshalJSON(t *testing.T) {
 	testCases := []struct {
 		name         string
 		data         []byte
-		expectedTime TimeMilli
+		expectedTime xtime.TimeMilli
 		expectedErr  error
 	}{
 		{
 			name:         "double-quoted string timestamp",
 			data:         []byte(`"1468185120499"`),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedErr:  nil,
 		},
 		{
 			name:         "number timestamp",
 			data:         []byte(`1468185120499`),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedErr:  nil,
 		},
 		{
 			name:         "RFC3339 string",
 			data:         []byte(`"2016-07-10T21:12:00+02:00"`),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:         "RFC3339Milli string",
 			data:         []byte(`"2016-07-10T21:12:00.499+02:00"`),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:         "RFC3339Nano string",
 			data:         []byte(`"2016-07-10T21:12:00.499+02:00"`),
-			expectedTime: ToMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+			expectedTime: xtime.ToMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
 		},
 	}
 
 	for _, tc := range testCases {
-		var gotTime TimeMilli
+		var gotTime xtime.TimeMilli
 		gotErr := gotTime.UnmarshalJSON(tc.data)
 
 		if !tc.expectedTime.Equal(gotTime.T()) {
@@ -584,34 +584,34 @@ func TestTimeMilli_UnmarshalText(t *testing.T) {
 	testCases := []struct {
 		name         string
 		data         []byte
-		expectedTime TimeMilli
+		expectedTime xtime.TimeMilli
 		expectedErr  error
 	}{
 		{
 			name:         "timestamp",
 			data:         []byte(`1468185120499`),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedErr:  nil,
 		},
 		{
 			name:         "RFC3339",
 			data:         []byte(`2016-07-10T21:12:00+02:00`),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:         "RFC3339Milli",
 			data:         []byte(`2016-07-10T21:12:00.499+02:00`),
-			expectedTime: DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expectedTime: xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:         "RFC3339Nano",
 			data:         []byte(`2016-07-10T21:12:00.499+02:00`),
-			expectedTime: ToMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+			expectedTime: xtime.ToMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
 		},
 	}
 
 	for _, tc := range testCases {
-		var gotTime TimeMilli
+		var gotTime xtime.TimeMilli
 		gotErr := gotTime.UnmarshalText(tc.data)
 
 		if !tc.expectedTime.Equal(gotTime.T()) {

--- a/xtime/timestamp_test.go
+++ b/xtime/timestamp_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/jlourenc/xgo/xtime"
+	"github.com/jlourenc/xgo/xtime"
 )
 
 func TestDateStampMilli(t *testing.T) {
@@ -77,7 +77,7 @@ func TestDateStampMilli(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := DateStampMilli(tc.year, tc.month, tc.day, tc.hour, tc.min, tc.sec, tc.msec, tc.loc)
+			got := xtime.DateStampMilli(tc.year, tc.month, tc.day, tc.hour, tc.min, tc.sec, tc.msec, tc.loc)
 			if !tc.expected.Equal(got.T()) {
 				t.Errorf("expected %s; got %s", tc.expected, got)
 			}
@@ -88,7 +88,7 @@ func TestDateStampMilli(t *testing.T) {
 func TestNowStampMilli(t *testing.T) {
 	before := time.Now()
 	time.Sleep(time.Millisecond)
-	got := NowStampMilli()
+	got := xtime.NowStampMilli()
 	time.Sleep(time.Millisecond)
 	after := time.Now()
 
@@ -99,7 +99,7 @@ func TestNowStampMilli(t *testing.T) {
 
 func TestToStampMilli(t *testing.T) {
 	expected := time.Now()
-	got := ToStampMilli(expected)
+	got := xtime.ToStampMilli(expected)
 
 	if !got.Equal(expected) {
 		t.Errorf("expected %s; got %s", expected, got)
@@ -135,7 +135,7 @@ func TestUnixStampMilli(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := UnixStampMilli(tc.sec, tc.msec)
+			got := xtime.UnixStampMilli(tc.sec, tc.msec)
 			if !tc.expected.Equal(got.T()) {
 				t.Errorf("expected %s; got %s", tc.expected, got)
 			}
@@ -146,27 +146,27 @@ func TestUnixStampMilli(t *testing.T) {
 func TestTimestampMilli_Add(t *testing.T) {
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
+		timestamp xtime.TimestampMilli
 		duration  time.Duration
-		expected  TimestampMilli
+		expected  xtime.TimestampMilli
 	}{
 		{
 			name:      "zero duration",
-			timestamp: UnixStampMilli(1468181520, 499),
+			timestamp: xtime.UnixStampMilli(1468181520, 499),
 			duration:  0,
-			expected:  UnixStampMilli(1468181520, 499),
+			expected:  xtime.UnixStampMilli(1468181520, 499),
 		},
 		{
 			name:      "positive duration",
-			timestamp: UnixStampMilli(1468181520, 499),
+			timestamp: xtime.UnixStampMilli(1468181520, 499),
 			duration:  20 * time.Second,
-			expected:  UnixStampMilli(1468181540, 499),
+			expected:  xtime.UnixStampMilli(1468181540, 499),
 		},
 		{
 			name:      "negative duration",
-			timestamp: UnixStampMilli(1468181520, 499),
+			timestamp: xtime.UnixStampMilli(1468181520, 499),
 			duration:  -20 * time.Second,
-			expected:  UnixStampMilli(1468181500, 499),
+			expected:  xtime.UnixStampMilli(1468181500, 499),
 		},
 	}
 
@@ -183,35 +183,35 @@ func TestTimestampMilli_Add(t *testing.T) {
 func TestTimestampMilli_AddDate(t *testing.T) {
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
+		timestamp xtime.TimestampMilli
 		years     int
 		months    int
 		days      int
-		expected  TimestampMilli
+		expected  xtime.TimestampMilli
 	}{
 		{
 			name:      "zero values",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			years:     0,
 			months:    0,
 			days:      0,
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:      "no overflow values",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			years:     3,
 			months:    2,
 			days:      1,
-			expected:  DateStampMilli(2019, time.September, 11, 21, 12, 0, 499, time.UTC),
+			expected:  xtime.DateStampMilli(2019, time.September, 11, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:      "with overflow values",
-			timestamp: DateStampMilli(2016, time.December, 31, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.December, 31, 21, 12, 0, 499, time.UTC),
 			years:     1,
 			months:    1,
 			days:      1,
-			expected:  DateStampMilli(2018, time.February, 1, 21, 12, 0, 499, time.UTC),
+			expected:  xtime.DateStampMilli(2018, time.February, 1, 21, 12, 0, 499, time.UTC),
 		},
 	}
 
@@ -228,21 +228,21 @@ func TestTimestampMilli_AddDate(t *testing.T) {
 func TestTimestampMilli_In(t *testing.T) {
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
+		timestamp xtime.TimestampMilli
 		location  *time.Location
-		expected  TimestampMilli
+		expected  xtime.TimestampMilli
 	}{
 		{
 			name:      "UTC to UTC",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			location:  time.UTC,
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:      "UTC to CET",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			location:  time.FixedZone("CET", 2*60*60),
-			expected:  DateStampMilli(2016, time.July, 10, 23, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 23, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 	}
 
@@ -260,18 +260,18 @@ func TestTimestampMilli_Local(t *testing.T) {
 	_, localOffset := time.Now().Local().Zone()
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
-		expected  TimestampMilli
+		timestamp xtime.TimestampMilli
+		expected  xtime.TimestampMilli
 	}{
 		{
 			name:      "from UTC",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, localOffset, 499, time.FixedZone("local", localOffset)),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, localOffset, 499, time.FixedZone("local", localOffset)),
 		},
 		{
 			name:      "from Local",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.Local),
 		},
 	}
 
@@ -288,19 +288,19 @@ func TestTimestampMilli_Local(t *testing.T) {
 func TestTimestampMilli_MarshalJSON(t *testing.T) {
 	testCases := []struct {
 		name          string
-		timestamp     TimestampMilli
+		timestamp     xtime.TimestampMilli
 		expectedBytes []byte
 		expectedErr   error
 	}{
 		{
 			name:          "UTC - with msec",
-			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp:     xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedBytes: []byte(`1468185120499`),
 			expectedErr:   nil,
 		},
 		{
 			name:          "zone info - no msec",
-			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			timestamp:     xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 			expectedBytes: []byte(`1468177920000`),
 			expectedErr:   nil,
 		},
@@ -325,19 +325,19 @@ func TestTimestampMilli_MarshalJSON(t *testing.T) {
 func TestTimestampMilli_MarshalText(t *testing.T) {
 	testCases := []struct {
 		name          string
-		timestamp     TimestampMilli
+		timestamp     xtime.TimestampMilli
 		expectedBytes []byte
 		expectedErr   error
 	}{
 		{
 			name:          "UTC - with msec",
-			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp:     xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedBytes: []byte(`1468185120499`),
 			expectedErr:   nil,
 		},
 		{
 			name:          "zone info - no msec",
-			timestamp:     DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			timestamp:     xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 			expectedBytes: []byte(`1468177920000`),
 			expectedErr:   nil,
 		},
@@ -362,17 +362,17 @@ func TestTimestampMilli_MarshalText(t *testing.T) {
 func TestTimestampMilli_Millisecond(t *testing.T) {
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
+		timestamp xtime.TimestampMilli
 		expected  int
 	}{
 		{
 			name:      "no msec",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 			expected:  0,
 		},
 		{
 			name:      "with msec",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expected:  499,
 		},
 	}
@@ -390,21 +390,21 @@ func TestTimestampMilli_Millisecond(t *testing.T) {
 func TestTimestampMilli_Round(t *testing.T) {
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
+		timestamp xtime.TimestampMilli
 		duration  time.Duration
-		expected  TimestampMilli
+		expected  xtime.TimestampMilli
 	}{
 		{
 			name:      "nearest second",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
 			duration:  2 * time.Second,
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 2, 0, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, 2, 0, time.UTC),
 		},
 		{
 			name:      "nearest hour",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			duration:  time.Hour,
-			expected:  DateStampMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
 		},
 	}
 
@@ -419,7 +419,7 @@ func TestTimestampMilli_Round(t *testing.T) {
 }
 
 func TestTimestampMilli_T(t *testing.T) {
-	x := DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC)
+	x := xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC)
 	expected := time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.UTC)
 	got := x.T()
 
@@ -431,21 +431,21 @@ func TestTimestampMilli_T(t *testing.T) {
 func TestTimestampMilli_Truncate(t *testing.T) {
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
+		timestamp xtime.TimestampMilli
 		duration  time.Duration
-		expected  TimestampMilli
+		expected  xtime.TimestampMilli
 	}{
 		{
 			name:      "rounding down to a multiple of 2 seconds",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 1, 499, time.UTC),
 			duration:  2 * time.Second,
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 		},
 		{
 			name:      "rounding down to nearest hour",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			duration:  time.Hour,
-			expected:  DateStampMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 0, 0, 0, time.UTC),
 		},
 	}
 
@@ -463,18 +463,18 @@ func TestTimestampMilli_UTC(t *testing.T) {
 	_, localOffset := time.Now().Local().Zone()
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
-		expected  TimestampMilli
+		timestamp xtime.TimestampMilli
+		expected  xtime.TimestampMilli
 	}{
 		{
 			name:      "from UTC",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 		},
 		{
 			name:      "from Local",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("local", localOffset)),
-			expected:  DateStampMilli(2016, time.July, 10, 21, 12, -localOffset, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("local", localOffset)),
+			expected:  xtime.DateStampMilli(2016, time.July, 10, 21, 12, -localOffset, 499, time.UTC),
 		},
 	}
 
@@ -491,17 +491,17 @@ func TestTimestampMilli_UTC(t *testing.T) {
 func TestTimestampMilli_UnixMilli(t *testing.T) {
 	testCases := []struct {
 		name      string
-		timestamp TimestampMilli
+		timestamp xtime.TimestampMilli
 		expected  int64
 	}{
 		{
 			name:      "no msec",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
 			expected:  1468185120000,
 		},
 		{
 			name:      "with msec",
-			timestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			timestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expected:  1468185120499,
 		},
 	}
@@ -520,40 +520,40 @@ func TestTimestampMilli_UnmarshalJSON(t *testing.T) {
 	testCases := []struct {
 		name              string
 		data              []byte
-		expectedTimestamp TimestampMilli
+		expectedTimestamp xtime.TimestampMilli
 		expectedErr       error
 	}{
 		{
 			name:              "double-quoted string timestamp",
 			data:              []byte(`"1468185120499"`),
-			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTimestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedErr:       nil,
 		},
 		{
 			name:              "number timestamp",
 			data:              []byte(`1468185120499`),
-			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTimestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedErr:       nil,
 		},
 		{
 			name:              "RFC3339 string",
 			data:              []byte(`"2016-07-10T21:12:00+02:00"`),
-			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedTimestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:              "RFC3339Milli string",
 			data:              []byte(`"2016-07-10T21:12:00.499+02:00"`),
-			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expectedTimestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:              "RFC3339Nano string",
 			data:              []byte(`"2016-07-10T21:12:00.499+02:00"`),
-			expectedTimestamp: ToStampMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+			expectedTimestamp: xtime.ToStampMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
 		},
 	}
 
 	for _, tc := range testCases {
-		var gotTime TimestampMilli
+		var gotTime xtime.TimestampMilli
 		gotErr := gotTime.UnmarshalJSON(tc.data)
 
 		if !tc.expectedTimestamp.Equal(gotTime.T()) {
@@ -571,34 +571,34 @@ func TestTimestampMilli_UnmarshalText(t *testing.T) {
 	testCases := []struct {
 		name              string
 		data              []byte
-		expectedTimestamp TimestampMilli
+		expectedTimestamp xtime.TimestampMilli
 		expectedErr       error
 	}{
 		{
 			name:              "timestamp",
 			data:              []byte(`1468185120499`),
-			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
+			expectedTimestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.UTC),
 			expectedErr:       nil,
 		},
 		{
 			name:              "RFC3339",
 			data:              []byte(`2016-07-10T21:12:00+02:00`),
-			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
+			expectedTimestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:              "RFC3339Milli",
 			data:              []byte(`2016-07-10T21:12:00.499+02:00`),
-			expectedTimestamp: DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
+			expectedTimestamp: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 499, time.FixedZone("CET", 2*60*60)),
 		},
 		{
 			name:              "RFC3339Nano",
 			data:              []byte(`2016-07-10T21:12:00.499+02:00`),
-			expectedTimestamp: ToStampMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
+			expectedTimestamp: xtime.ToStampMilli(time.Date(2016, time.July, 10, 21, 12, 0, 499000000, time.FixedZone("CET", 2*60*60))),
 		},
 	}
 
 	for _, tc := range testCases {
-		var gotTime TimestampMilli
+		var gotTime xtime.TimestampMilli
 		gotErr := gotTime.UnmarshalText(tc.data)
 
 		if !tc.expectedTimestamp.Equal(gotTime.T()) {

--- a/xunit/byte.go
+++ b/xunit/byte.go
@@ -132,7 +132,7 @@ strLoop:
 
 // Get returns the Byte value.
 // It makes Byte implement the flag package Getter interface.
-func (b Byte) Get() interface{} { return b }
+func (b Byte) Get() any { return b }
 
 // MarshalText implements the encoding.TextMarshaler interface.
 // The encoding is the same as returned by String.
@@ -178,7 +178,7 @@ func (b Byte) String() string {
 
 // Type returns a string representation of Byte type.
 // It makes Byte implement the pflag Value interface.
-func (b Byte) Type() string { return "xunit_byte" }
+func (Byte) Type() string { return "xunit_byte" }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // The text is expected in a form accepted by ParseByte.

--- a/xunit/byte_test.go
+++ b/xunit/byte_test.go
@@ -8,13 +8,13 @@ import (
 	"errors"
 	"testing"
 
-	. "github.com/jlourenc/xgo/xunit"
+	"github.com/jlourenc/xgo/xunit"
 )
 
 func TestParseByte(t *testing.T) {
 	testCases := []struct {
 		input        string
-		expectedByte Byte
+		expectedByte xunit.Byte
 		expectedErr  error
 	}{
 		{"", 0, errors.New("empty byte representation")},
@@ -24,54 +24,54 @@ func TestParseByte(t *testing.T) {
 		{"9223372036854775808", 0, errors.New("invalid byte representation: 9223372036854775808")},
 		{"-9223372036854775809", 0, errors.New("invalid byte representation: -9223372036854775809")},
 		{"-9223372036854775808", -9223372036854775808, nil},
-		{"-2PB", -2 * PB, nil},
-		{"-2pb", -2 * PB, nil},
-		{"-2Pb", -2 * PB, nil},
-		{"-1TB", -TB, nil},
-		{"-1TiB", -TiB, nil},
+		{"-2PB", -2 * xunit.PB, nil},
+		{"-2pb", -2 * xunit.PB, nil},
+		{"-2Pb", -2 * xunit.PB, nil},
+		{"-1TB", -xunit.TB, nil},
+		{"-1TiB", -xunit.TiB, nil},
 		{"-4096.75MiB", -4295753728, nil},
 		{"-4096.5MiB", -4295491584, nil},
 		{"-4096.25MiB", -4295229440, nil},
-		{"-4096.000MiB", -4 * GiB, nil},
-		{"-4096.0MiB", -4 * GiB, nil},
-		{"-3GiB", -3 * GiB, nil},
-		{"-3GB", -3 * GB, nil},
+		{"-4096.000MiB", -4 * xunit.GiB, nil},
+		{"-4096.0MiB", -4 * xunit.GiB, nil},
+		{"-3GiB", -3 * xunit.GiB, nil},
+		{"-3GB", -3 * xunit.GB, nil},
 		{"-1.5GiB", -1610612736, nil},
 		{"-1.5GB", -1500000000, nil},
-		{"-5MiB", -5 * MiB, nil},
-		{"-5MB", -5 * MB, nil},
+		{"-5MiB", -5 * xunit.MiB, nil},
+		{"-5MB", -5 * xunit.MB, nil},
 		{"-1.5Mib", -1572864, nil},
-		{"-10KiB", -10 * KiB, nil},
-		{"-10KB", -10 * KB, nil},
-		{"-1B", -B, nil},
+		{"-10KiB", -10 * xunit.KiB, nil},
+		{"-10KB", -10 * xunit.KB, nil},
+		{"-1B", -xunit.B, nil},
 		{"-0", 0, nil},
 		{"0", 0, nil},
-		{"1B", B, nil},
-		{"10KB", 10 * KB, nil},
-		{"10KiB", 10 * KiB, nil},
+		{"1B", xunit.B, nil},
+		{"10KB", 10 * xunit.KB, nil},
+		{"10KiB", 10 * xunit.KiB, nil},
 		{"1.5Mib", 1572864, nil},
-		{"5MB", 5 * MB, nil},
-		{"5MiB", 5 * MiB, nil},
+		{"5MB", 5 * xunit.MB, nil},
+		{"5MiB", 5 * xunit.MiB, nil},
 		{"1.5GB", 1500000000, nil},
 		{"1.5GiB", 1610612736, nil},
-		{"3GB", 3 * GB, nil},
-		{"3GiB", 3 * GiB, nil},
-		{"4096.0MiB", 4 * GiB, nil},
-		{"4096.000MiB", 4 * GiB, nil},
+		{"3GB", 3 * xunit.GB, nil},
+		{"3GiB", 3 * xunit.GiB, nil},
+		{"4096.0MiB", 4 * xunit.GiB, nil},
+		{"4096.000MiB", 4 * xunit.GiB, nil},
 		{"4096.25MiB", 4295229440, nil},
 		{"4096.5MiB", 4295491584, nil},
 		{"4096.75MiB", 4295753728, nil},
-		{"1TiB", TiB, nil},
-		{"1TB", TB, nil},
-		{"2Pb", 2 * PB, nil},
-		{"2pb", 2 * PB, nil},
-		{"2PB", 2 * PB, nil},
+		{"1TiB", xunit.TiB, nil},
+		{"1TB", xunit.TB, nil},
+		{"2Pb", 2 * xunit.PB, nil},
+		{"2pb", 2 * xunit.PB, nil},
+		{"2PB", 2 * xunit.PB, nil},
 		{"9223372036854775807", 9223372036854775807, nil},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			qty, err := ParseByte(tc.input)
+			qty, err := xunit.ParseByte(tc.input)
 
 			if tc.expectedByte != qty {
 				t.Errorf("expected %s; got %s", tc.expectedByte, qty)
@@ -86,7 +86,7 @@ func TestParseByte(t *testing.T) {
 }
 
 func TestByte_Get(t *testing.T) {
-	b := 2*MiB + 512*KiB
+	b := 2*xunit.MiB + 512*xunit.KiB
 
 	got := b.Get()
 
@@ -99,7 +99,7 @@ func TestByte_Set(t *testing.T) {
 	testCases := []struct {
 		name         string
 		input        string
-		expectedByte Byte
+		expectedByte xunit.Byte
 		expectedErr  error
 	}{
 		{
@@ -115,13 +115,13 @@ func TestByte_Set(t *testing.T) {
 		{
 			name:         "valid byte representation",
 			input:        "2MiB",
-			expectedByte: 2 * MiB,
+			expectedByte: 2 * xunit.MiB,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var b Byte
+			var b xunit.Byte
 
 			err := b.Set(tc.input)
 
@@ -140,50 +140,50 @@ func TestByte_Set(t *testing.T) {
 func TestByte_MarshalText_String(t *testing.T) {
 	testCases := []struct {
 		name     string
-		input    Byte
+		input    xunit.Byte
 		expected string
 	}{
 		{"-9223372036854775808", -9223372036854775808, "-8EiB"},
-		{"-2PB", -2 * PB, "-2PB"},
-		{"-10TiB", -10 * TiB, "-10TiB"},
-		{"-1TB", -TB, "-1TB"},
+		{"-2PB", -2 * xunit.PB, "-2PB"},
+		{"-10TiB", -10 * xunit.TiB, "-10TiB"},
+		{"-1TB", -xunit.TB, "-1TB"},
 		{"-4096.75MiB", -4295753728, "-4096.75MiB"},
 		{"-4096.5MiB", -4295491584, "-4096.5MiB"},
 		{"-4096.25MiB", -4295229440, "-4096.25MiB"},
-		{"-4096.0MiB", -4 * GiB, "-4GiB"},
-		{"-4096.000MiB", -4 * GiB, "-4GiB"},
+		{"-4096.0MiB", -4 * xunit.GiB, "-4GiB"},
+		{"-4096.000MiB", -4 * xunit.GiB, "-4GiB"},
 		{"-1.5GiB", -1610612736, "-1.5GiB"},
 		{"-1.5GB", -1500000000, "-1.5GB"},
-		{"-1GiB", -GiB, "-1GiB"},
-		{"-1GB", -GB, "-1GB"},
+		{"-1GiB", -xunit.GiB, "-1GiB"},
+		{"-1GB", -xunit.GB, "-1GB"},
 		{"-1.5Mib", -1572864, "-1.5MiB"},
-		{"-1MiB", -MiB, "-1MiB"},
-		{"-1MB", -MB, "-1MB"},
-		{"-1KiB", -KiB, "-1KiB"},
-		{"-1KB", -KB, "-1KB"},
-		{"-1B", -B, "-1B"},
+		{"-1MiB", -xunit.MiB, "-1MiB"},
+		{"-1MB", -xunit.MB, "-1MB"},
+		{"-1KiB", -xunit.KiB, "-1KiB"},
+		{"-1KB", -xunit.KB, "-1KB"},
+		{"-1B", -xunit.B, "-1B"},
 		{"-0", 0, "0B"},
 		{"0", 0, "0B"},
-		{"1B", B, "1B"},
-		{"1KB", KB, "1KB"},
-		{"1KiB", KiB, "1KiB"},
-		{"1MB", MB, "1MB"},
-		{"1MiB", MiB, "1MiB"},
-		{"512MiB", 512 * MiB, "512MiB"},
-		{"768MiB", 768 * MiB, "768MiB"},
+		{"1B", xunit.B, "1B"},
+		{"1KB", xunit.KB, "1KB"},
+		{"1KiB", xunit.KiB, "1KiB"},
+		{"1MB", xunit.MB, "1MB"},
+		{"1MiB", xunit.MiB, "1MiB"},
+		{"512MiB", 512 * xunit.MiB, "512MiB"},
+		{"768MiB", 768 * xunit.MiB, "768MiB"},
 		{"1.5Mib", 1572864, "1.5MiB"},
-		{"1GB", GB, "1GB"},
-		{"1GiB", GiB, "1GiB"},
+		{"1GB", xunit.GB, "1GB"},
+		{"1GiB", xunit.GiB, "1GiB"},
 		{"1.5GB", 1500000000, "1.5GB"},
 		{"1.5GiB", 1610612736, "1.5GiB"},
-		{"4096.000MiB", 4 * GiB, "4GiB"},
-		{"4096.0MiB", 4 * GiB, "4GiB"},
+		{"4096.000MiB", 4 * xunit.GiB, "4GiB"},
+		{"4096.0MiB", 4 * xunit.GiB, "4GiB"},
 		{"4096.25MiB", 4295229440, "4096.25MiB"},
 		{"4096.5MiB", 4295491584, "4096.5MiB"},
 		{"4096.75MiB", 4295753728, "4096.75MiB"},
-		{"1TB", TB, "1TB"},
-		{"10TiB", 10 * TiB, "10TiB"},
-		{"2PB", 2 * PB, "2PB"},
+		{"1TB", xunit.TB, "1TB"},
+		{"10TiB", 10 * xunit.TiB, "10TiB"},
+		{"2PB", 2 * xunit.PB, "2PB"},
 		{"9223372036854775807", 9223372036854775807, "8EiB"},
 	}
 
@@ -210,7 +210,7 @@ func TestByte_MarshalText_String(t *testing.T) {
 }
 
 func TestByte_Type(t *testing.T) {
-	var b Byte
+	var b xunit.Byte
 	expected := "xunit_byte"
 
 	got := b.Type()
@@ -224,7 +224,7 @@ func TestByte_UnmarshalText(t *testing.T) {
 	testCases := []struct {
 		name         string
 		input        string
-		expectedByte Byte
+		expectedByte xunit.Byte
 		expectedErr  error
 	}{
 		{
@@ -240,13 +240,13 @@ func TestByte_UnmarshalText(t *testing.T) {
 		{
 			name:         "valid byte representation",
 			input:        "2MiB",
-			expectedByte: 2 * MiB,
+			expectedByte: 2 * xunit.MiB,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var b Byte
+			var b xunit.Byte
 
 			err := b.UnmarshalText([]byte(tc.input))
 
@@ -277,7 +277,7 @@ func TestByte_B(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.B()
 
 			if tc.expected != got {
@@ -304,7 +304,7 @@ func TestByte_KB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.KB()
 
 			if tc.expected != got {
@@ -331,7 +331,7 @@ func TestByte_KiB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.KiB()
 
 			if tc.expected != got {
@@ -358,7 +358,7 @@ func TestByte_MB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.MB()
 
 			if tc.expected != got {
@@ -385,7 +385,7 @@ func TestByte_MiB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.MiB()
 
 			if tc.expected != got {
@@ -412,7 +412,7 @@ func TestByte_GB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.GB()
 
 			if tc.expected != got {
@@ -439,7 +439,7 @@ func TestByte_GiB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.GiB()
 
 			if tc.expected != got {
@@ -466,7 +466,7 @@ func TestByte_TB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.TB()
 
 			if tc.expected != got {
@@ -493,7 +493,7 @@ func TestByte_TiB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.TiB()
 
 			if tc.expected != got {
@@ -520,7 +520,7 @@ func TestByte_PB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.PB()
 
 			if tc.expected != got {
@@ -547,7 +547,7 @@ func TestByte_PiB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.PiB()
 
 			if tc.expected != got {
@@ -574,7 +574,7 @@ func TestByte_EB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.EB()
 
 			if tc.expected != got {
@@ -601,7 +601,7 @@ func TestByte_EiB(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			b, _ := ParseByte(tc.input)
+			b, _ := xunit.ParseByte(tc.input)
 			got := b.EiB()
 
 			if tc.expected != got {


### PR DESCRIPTION
Upgrade golangci-lint to v1.55
Adds a few more linters, notably revive.
Refactors code (tests) accordingly.