### PR TITLE
feat(xhttp): HTTP retry transport

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -168,9 +168,14 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
+        - bodyclose
         - dupl
         - errcheck
         - goconst
         - gomnd
         - govet
         - lll
+    - path: _test\.go
+      text: "function-length"
+      linters:
+        - revive

--- a/xnet/xhttp/header.go
+++ b/xnet/xhttp/header.go
@@ -200,6 +200,8 @@ const (
 
 // HTTP non-standard headers, but widely used.
 const (
+	// https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/
+	HeaderIdempotencyKey = "Idempotency-Key"
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
 	HeaderXContentTypeOptions = "X-Content-Type-Options"
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control
@@ -213,6 +215,7 @@ const (
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 	HeaderXFrameOptions = "X-Frame-Options"
 	// https://tools.ietf.org/id/draft-idempotency-header-01.html
+	// Deprecated: use HeaderIdempotencyKey instead.
 	HeaderXIdempotencyKey = "X-Idempotency-Key"
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
 	HeaderXXSSProtection = "X-XSS-Protection"

--- a/xnet/xhttp/helper_test.go
+++ b/xnet/xhttp/helper_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package xhttp_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/jlourenc/xgo/xnet/xhttp"
+)
+
+var (
+	errNoBody     = errors.New("no body")
+	errNoResponse = errors.New("no response")
+)
+
+type fakeTransport struct {
+	counter   int
+	reqBodies [][]byte
+	resps     []*http.Response
+}
+
+func (t *fakeTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	var b []byte
+	if req.Body == nil {
+		return nil, errNoBody
+	}
+
+	b, err = io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	t.reqBodies = append(t.reqBodies, b)
+
+	if t.counter >= len(t.resps) {
+		return nil, errNoResponse
+	}
+
+	resp = t.resps[t.counter]
+	t.counter++
+
+	return resp, nil
+}
+
+func testRetryTransportOptionPanic(tb testing.TB, shouldPanic bool, fn func() xhttp.RetryTransportOption) {
+	tb.Helper()
+
+	defer func() {
+		r := recover()
+		if r == nil && shouldPanic {
+			tb.Error("panic expected; got none")
+		} else if r != nil && !shouldPanic {
+			tb.Error("no panic expected; got one")
+		}
+	}()
+
+	got := fn()
+
+	if got == nil {
+		tb.Error("retry option expected; got nil")
+	}
+}

--- a/xnet/xhttp/retrytransport.go
+++ b/xnet/xhttp/retrytransport.go
@@ -1,0 +1,240 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package xhttp
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jlourenc/xgo/xio"
+	"github.com/jlourenc/xgo/xnet/xhttp/xhttptrace"
+)
+
+const (
+	defaultInitialInterval    = 200 * time.Millisecond
+	defaultIntervalMultiplier = 1.5
+	defaultJitterFactor       = 0.2
+	defaultMaxInterval        = 30 * time.Second
+)
+
+// RetryTransport is an HTTP transport that implements HTTP retries according to
+// the HTTP semantics defined in https://datatracker.ietf.org/doc/html/rfc9110.
+type retryTransport struct {
+	next http.RoundTripper
+
+	// backoff policy
+	initialInterval    time.Duration
+	intervalMultiplier float64
+	jitterFactor       float64
+	maxInterval        time.Duration
+}
+
+// NewRetryTransport creates a new RetryTransport configured with the options passed in input,
+// notably the backoff policy and the next round tripper in the chain.
+func NewRetryTransport(options ...RetryTransportOption) http.RoundTripper {
+	t := &retryTransport{
+		initialInterval:    defaultInitialInterval,
+		intervalMultiplier: defaultIntervalMultiplier,
+		jitterFactor:       defaultJitterFactor,
+		maxInterval:        defaultMaxInterval,
+		next:               http.DefaultTransport,
+	}
+
+	for _, opt := range options {
+		opt.apply(t)
+	}
+
+	return t
+}
+
+// RoundTrip makes RetryTransport implement the RoundTripper interface.
+//
+// It retries retryable (as defined by their status code) responses of idempotent requests,
+// following a backoff policy or respecting Retry-After response headers.
+//
+// See HTTP semantics defined in: https://datatracker.ietf.org/doc/html/rfc9110.
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	reqRetryable := isRequestRetryable(req.Method, req.Header)
+	reqRewindable := req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+	retryCount := 0
+	retryInterval := t.initialInterval
+
+	trace := xhttptrace.ContextClientTrace(ctx)
+	if trace == nil {
+		trace = &xhttptrace.ClientTrace{}
+	}
+
+	for {
+		resp, err := t.next.RoundTrip(req)
+		if err != nil {
+			return resp, err
+		}
+
+		if !isResponseRetryable(resp.StatusCode, resp.Header) || !reqRetryable || !reqRewindable {
+			return resp, nil
+		}
+
+		// Clone request if body is rewindable.
+		if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return resp, nil //nolint:nilerr // return last response
+			}
+			req = req.Clone(ctx)
+			req.Body = body
+		}
+
+		timer := time.NewTimer(computeWaitDuration(retryInterval, t.jitterFactor, resp.Header))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return resp, nil
+		case <-timer.C:
+			xio.DrainClose(resp.Body)
+		}
+
+		retryInterval = time.Duration(float64(retryInterval) * t.intervalMultiplier)
+		if retryInterval > t.maxInterval {
+			retryInterval = t.maxInterval
+		}
+		retryCount++
+
+		if trace.Retry != nil {
+			trace.Retry(xhttptrace.RetryInfo{
+				RetryCount: retryCount,
+				StatusCode: resp.StatusCode,
+			})
+		}
+	}
+}
+
+func computeWaitDuration(interval time.Duration, jitterFactor float64, headers http.Header) time.Duration {
+	if retryAfter := headers.Get(HeaderRetryAfter); retryAfter != "" {
+		if date, err := time.Parse(time.RFC1123, retryAfter); err == nil {
+			return time.Until(date)
+		}
+
+		if secs, err := strconv.Atoi(retryAfter); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+	}
+
+	if jitterFactor == 0.0 {
+		return interval
+	}
+
+	delta := jitterFactor * float64(interval)
+	minInterval := float64(interval) - delta
+
+	// returns a random value in the half-open interval [interval - delta, interval + delta).
+	return time.Duration(minInterval + (rand.Float64() * delta * 2)) //nolint:gosec // rand is used in a non security-sensitive scenario
+}
+
+func isRequestRetryable(method string, headers http.Header) bool {
+	switch method {
+	// idempotent methods: https://datatracker.ietf.org/doc/html/rfc9110#name-idempotent-methods
+	case http.MethodDelete, http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodPut, http.MethodTrace:
+		return true
+	default:
+		// Any method is retryable if either Idempotency-Key or X-Idempotency-Key request header is set.
+		return headers.Get(HeaderIdempotencyKey) != "" || headers.Get(HeaderXIdempotencyKey) != ""
+	}
+}
+
+func isResponseRetryable(statusCode int, headers http.Header) bool {
+	switch statusCode {
+	// 4xx status codes
+	case http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests:
+		return true
+	// 413 is retryable if Retry-After header is set.
+	case http.StatusRequestEntityTooLarge:
+		return headers.Get(HeaderRetryAfter) != ""
+	// 5xx status codes
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+type (
+	// RetryTransportOption configures the RetryTransport options
+	// when calling NewRetryTransport.
+	RetryTransportOption interface {
+		apply(d *retryTransport)
+	}
+
+	funcRetryTransportOption struct {
+		fn func(*retryTransport)
+	}
+)
+
+func newFuncRetryTransportOption(fn func(*retryTransport)) funcRetryTransportOption {
+	return funcRetryTransportOption{
+		fn: fn,
+	}
+}
+
+func (o funcRetryTransportOption) apply(d *retryTransport) {
+	o.fn(d)
+}
+
+// RetryTransportInitialInterval returns a RetryTransportOption that configures the
+// initial retry interval of the backoff policy. Value must be > 0, otherwise it panics.
+func RetryTransportInitialInterval(interval time.Duration) RetryTransportOption {
+	if interval <= 0 {
+		panic("invalid initial interval value")
+	}
+	return newFuncRetryTransportOption(func(rt *retryTransport) {
+		rt.initialInterval = interval
+	})
+}
+
+// RetryTransportIntervalMultiplier returns a RetryTransportOption that configures the
+// interval multiplier of the backoff policy. Value must be >= 1.0, otherwise it panics.
+func RetryTransportIntervalMultiplier(multiplier float64) RetryTransportOption {
+	if multiplier < 1.0 {
+		panic("invalid interval multiplier value")
+	}
+	return newFuncRetryTransportOption(func(rt *retryTransport) {
+		rt.intervalMultiplier = multiplier
+	})
+}
+
+// RetryTransportJitterFactor returns a RetryTransportOption that configures the jitter
+// multiplier of the backoff policy to randomize the retry distribution. Value must be in the
+// [0.0, 1.0] range, otherwise it panics.
+func RetryTransportJitterFactor(factor float64) RetryTransportOption {
+	if factor < 0.0 || factor > 1.0 {
+		panic("invalid jitter factor value")
+	}
+	return newFuncRetryTransportOption(func(rt *retryTransport) {
+		rt.jitterFactor = factor
+	})
+}
+
+// RetryTransportMaxInterval returns a RetryTransportOption that configures the max interval of the
+// backoff policy. Once reached, retry interval is not increased. Value must be > 0, otherwise it panics.
+func RetryTransportMaxInterval(interval time.Duration) RetryTransportOption {
+	if interval <= 0 {
+		panic("invalid max interval value")
+	}
+	return newFuncRetryTransportOption(func(rt *retryTransport) {
+		rt.maxInterval = interval
+	})
+}
+
+// RetryTransportNextRoundTripper returns a RetryTransportOption that configures the
+// next round tripper to call. If not used http.DefaultTransport will be used.
+func RetryTransportNextRoundTripper(next http.RoundTripper) RetryTransportOption {
+	if next == nil {
+		panic("next http.RoundTripper is nil")
+	}
+	return newFuncRetryTransportOption(func(rt *retryTransport) {
+		rt.next = next
+	})
+}

--- a/xnet/xhttp/retrytransport_test.go
+++ b/xnet/xhttp/retrytransport_test.go
@@ -1,0 +1,329 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package xhttp_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jlourenc/xgo/xnet/xhttp"
+	"github.com/jlourenc/xgo/xnet/xhttp/xhttptrace"
+)
+
+func TestRetryTransport_RoundTrip(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	traceRetryCalled := false
+	traceCtx := xhttptrace.WithClientTrace(context.Background(), &xhttptrace.ClientTrace{
+		Retry: func(ri xhttptrace.RetryInfo) {
+			traceRetryCalled = true
+			if ri.RetryCount <= 0 {
+				t.Errorf("retry count less than or equal to 0: %d", ri.RetryCount)
+			}
+			if ri.StatusCode != http.StatusServiceUnavailable {
+				t.Errorf("status code mismatch: expected %d; got %d", http.StatusServiceUnavailable, ri.StatusCode)
+			}
+		},
+	})
+	defer func() {
+		if !traceRetryCalled {
+			t.Error("trace retry function did not get called")
+		}
+	}()
+
+	u, _ := url.Parse("http://example.com")
+	resp204 := &http.Response{StatusCode: http.StatusNoContent}
+	resp413 := &http.Response{
+		Header:     http.Header{xhttp.HeaderRetryAfter: []string{"1"}},
+		StatusCode: http.StatusRequestEntityTooLarge,
+	}
+	resp429 := &http.Response{
+		Header:     http.Header{xhttp.HeaderRetryAfter: []string{time.Now().Add(50 * time.Millisecond).Format(time.RFC1123)}},
+		StatusCode: http.StatusTooManyRequests,
+	}
+	resp503 := &http.Response{StatusCode: http.StatusServiceUnavailable}
+
+	testCases := []struct {
+		name         string
+		ctx          context.Context //nolint:containedctx // ctx appended to req object
+		jitterFactor float64
+		next         http.RoundTripper
+		req          *http.Request
+		expectedResp *http.Response
+		expectedErr  error
+	}{
+		{
+			name: "next round trip error bubbles up as is",
+			next: &fakeTransport{},
+			req: &http.Request{
+				Body:   http.NoBody,
+				Method: http.MethodGet,
+				URL:    u,
+			},
+			expectedErr: errNoResponse,
+		},
+		{
+			name: "success response with no retry",
+			next: &fakeTransport{resps: []*http.Response{resp204}},
+			req: &http.Request{
+				Body:   io.NopCloser(strings.NewReader("payload")),
+				Method: http.MethodPut,
+				URL:    u,
+			},
+			expectedResp: resp204,
+		},
+		{
+			name: "success response with a single retry on 413 with retry-after header",
+			next: &fakeTransport{resps: []*http.Response{resp413, resp204}},
+			req: &http.Request{
+				Body: io.NopCloser(strings.NewReader("payload")),
+				GetBody: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("payload")), nil
+				},
+				Header: http.Header{
+					xhttp.HeaderIdempotencyKey: []string{"idempotency-key-id"},
+				},
+				Method: http.MethodPost,
+				URL:    u,
+			},
+			expectedResp: resp204,
+		},
+		{
+			name: "success response with a single retry on 429",
+			next: &fakeTransport{resps: []*http.Response{resp429, resp204}},
+			req: &http.Request{
+				Body: io.NopCloser(strings.NewReader("payload")),
+				GetBody: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("payload")), nil
+				},
+				Header: http.Header{
+					xhttp.HeaderXIdempotencyKey: []string{"idempotency-key-id"},
+				},
+				Method: http.MethodPost,
+				URL:    u,
+			},
+			expectedResp: resp204,
+		},
+		{
+			name: "success response with multiple retries on 503",
+			next: &fakeTransport{resps: []*http.Response{resp503, resp503, resp503, resp204}},
+			req: &http.Request{
+				Body: io.NopCloser(strings.NewReader("payload")),
+				GetBody: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("payload")), nil
+				},
+				Method: http.MethodPut,
+				URL:    u,
+			},
+			jitterFactor: 0.5,
+			expectedResp: resp204,
+		},
+		{
+			name: "failure to rewing body returns last http response",
+
+			next: &fakeTransport{resps: []*http.Response{resp429, resp204}},
+			req: &http.Request{
+				Body: io.NopCloser(strings.NewReader("payload")),
+				GetBody: func() (io.ReadCloser, error) {
+					return nil, errNoBody
+				},
+				Method: http.MethodPut,
+				URL:    u,
+			},
+			expectedResp: resp429,
+		},
+		{
+			name: "context done cancels retry and returns last http response",
+			ctx:  canceledCtx,
+			next: &fakeTransport{resps: []*http.Response{resp429, resp204}},
+			req: &http.Request{
+				Body:   http.NoBody,
+				Method: http.MethodDelete,
+				URL:    u,
+			},
+			expectedResp: resp429,
+		},
+		{
+			name: "trace retry called on retries",
+			ctx:  traceCtx,
+			next: &fakeTransport{resps: []*http.Response{resp503, resp503, resp204}},
+			req: &http.Request{
+				Body:   http.NoBody,
+				Method: http.MethodDelete,
+				URL:    u,
+			},
+			expectedResp: resp204,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			retryTransp := xhttp.NewRetryTransport(
+				xhttp.RetryTransportNextRoundTripper(tc.next),
+				xhttp.RetryTransportInitialInterval(10*time.Millisecond),
+				xhttp.RetryTransportIntervalMultiplier(2),
+				xhttp.RetryTransportJitterFactor(tc.jitterFactor),
+				xhttp.RetryTransportMaxInterval(20*time.Millisecond))
+
+			if tc.ctx != nil {
+				tc.req = tc.req.Clone(tc.ctx)
+			}
+
+			gotResp, gotErr := retryTransp.RoundTrip(tc.req)
+
+			if gotResp != tc.expectedResp {
+				t.Errorf("response mistmatch: %v != %v", gotResp, tc.expectedResp)
+			}
+			if gotErr != tc.expectedErr {
+				t.Errorf("error mistmach: %v != %v", gotErr, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestRetryTransportInitialInterval(t *testing.T) {
+	testCases := []struct {
+		name     string
+		interval time.Duration
+		panic    bool
+	}{
+		{
+			name:     "panic",
+			interval: 0,
+			panic:    true,
+		},
+		{
+			name:     "valid",
+			interval: 1,
+			panic:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testRetryTransportOptionPanic(t, tc.panic, func() xhttp.RetryTransportOption {
+				return xhttp.RetryTransportInitialInterval(tc.interval)
+			})
+		})
+	}
+}
+
+func TestRetryTransportIntervalMultiplier(t *testing.T) {
+	testCases := []struct {
+		name       string
+		multiplier float64
+		panic      bool
+	}{
+		{
+			name:       "panic",
+			multiplier: 0.0,
+			panic:      true,
+		},
+		{
+			name:       "valid",
+			multiplier: 1.0,
+			panic:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testRetryTransportOptionPanic(t, tc.panic, func() xhttp.RetryTransportOption {
+				return xhttp.RetryTransportIntervalMultiplier(tc.multiplier)
+			})
+		})
+	}
+}
+
+func TestRetryTransportJitterFactor(t *testing.T) {
+	testCases := []struct {
+		name   string
+		factor float64
+		panic  bool
+	}{
+		{
+			name:   "panic - below range",
+			factor: -0.1,
+			panic:  true,
+		},
+		{
+			name:   "panic - above range",
+			factor: 1.1,
+			panic:  true,
+		},
+		{
+			name:   "valid",
+			factor: 0.5,
+			panic:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testRetryTransportOptionPanic(t, tc.panic, func() xhttp.RetryTransportOption {
+				return xhttp.RetryTransportJitterFactor(tc.factor)
+			})
+		})
+	}
+}
+
+func TestRetryTransportMaxInterval(t *testing.T) {
+	testCases := []struct {
+		name     string
+		interval time.Duration
+		panic    bool
+	}{
+		{
+			name:     "panic",
+			interval: 0,
+			panic:    true,
+		},
+		{
+			name:     "valid",
+			interval: 1,
+			panic:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testRetryTransportOptionPanic(t, tc.panic, func() xhttp.RetryTransportOption {
+				return xhttp.RetryTransportMaxInterval(tc.interval)
+			})
+		})
+	}
+}
+
+func TestRetryTransportNextRoundTripper(t *testing.T) {
+	testCases := []struct {
+		name  string
+		next  http.RoundTripper
+		panic bool
+	}{
+		{
+			name:  "panic",
+			next:  nil,
+			panic: true,
+		},
+		{
+			name:  "valid",
+			next:  &fakeTransport{},
+			panic: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testRetryTransportOptionPanic(t, tc.panic, func() xhttp.RetryTransportOption {
+				return xhttp.RetryTransportNextRoundTripper(tc.next)
+			})
+		})
+	}
+}

--- a/xnet/xhttp/xhttptrace/example_test.go
+++ b/xnet/xhttp/xhttptrace/example_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xhttptrace_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/jlourenc/xgo/xnet/xhttp/xhttptrace"
+)
+
+func Example() {
+	ctx := context.Background()
+	ctx = xhttptrace.WithClientTrace(ctx, &xhttptrace.ClientTrace{
+		Retry: func(ri xhttptrace.RetryInfo) {
+			fmt.Printf("retry count: %d, status code: %d", ri.RetryCount, ri.StatusCode)
+		},
+	})
+
+	trace := xhttptrace.ContextClientTrace(ctx)
+	trace.Retry(xhttptrace.RetryInfo{
+		RetryCount: 1,
+		StatusCode: http.StatusTooManyRequests,
+	})
+
+	// Output: retry count: 1, status code: 429
+}

--- a/xnet/xhttp/xhttptrace/trace.go
+++ b/xnet/xhttp/xhttptrace/trace.go
@@ -1,0 +1,46 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xhttptrace
+
+import (
+	"context"
+)
+
+type (
+	// ClientTrace is a set of hooks to run at various stages of an outgoing
+	// HTTP request. Any particular hook may be nil.
+	ClientTrace struct {
+		// Retry is called before a round trip retry is made.
+		Retry func(RetryInfo)
+	}
+
+	// RetryInfo contains information about the HTTP request retry.
+	RetryInfo struct {
+		// RetryCount is the retry count for a given HTTP request.
+		RetryCount int
+
+		// StatusCode specifies the HTTP response code gotten before trigering a retry.
+		StatusCode int
+	}
+
+	clientEventContextKey struct{}
+)
+
+// ContextClientTrace returns the ClientTrace value stored in ctx.
+// If none, it returns nil.
+func ContextClientTrace(ctx context.Context) *ClientTrace {
+	trace, _ := ctx.Value(clientEventContextKey{}).(*ClientTrace) //nolint:errcheck,revive // nil returned if none.
+	return trace
+}
+
+// WithClientTrace returns a new context based on the provided parent ctx.
+// HTTP client requests made with the returned context will use
+// the provided trace hooks.
+func WithClientTrace(parent context.Context, trace *ClientTrace) context.Context {
+	if trace == nil {
+		return parent
+	}
+	return context.WithValue(parent, clientEventContextKey{}, trace)
+}

--- a/xnet/xhttp/xhttptrace/trace_test.go
+++ b/xnet/xhttp/xhttptrace/trace_test.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xhttptrace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jlourenc/xgo/xnet/xhttp/xhttptrace"
+)
+
+func TestContextClientTrace(t *testing.T) {
+	testCases := []struct {
+		name          string
+		trace         *xhttptrace.ClientTrace
+		expectedTrace *xhttptrace.ClientTrace
+		expectedOK    bool
+	}{
+		{
+			name:  "nil trace",
+			trace: nil,
+		},
+		{
+			name: "specified trace",
+			trace: &xhttptrace.ClientTrace{
+				Retry: func(ri xhttptrace.RetryInfo) {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := xhttptrace.WithClientTrace(context.Background(), tc.trace)
+
+			got := xhttptrace.ContextClientTrace(ctx)
+
+			if tc.trace != got {
+				t.Errorf("expected %v; got %v", tc.trace, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change implements an HTTP retry transport following HTTP semantics as defined in https://datatracker.ietf.org/doc/html/rfc9110.

When the transport is chained to an HTTP client transport, it retries requests when all the following conditions are met:
- request is retryable, either because the request method is idempotent or the request contains an Idempotency-Key header,
- response contains a retryable status code (with an eventual "Retry-After" header): 408, 413, 425, 429, 500, 502, 503 or 504.

Requests are retried with a configurable backoff policy, which defaults to:
- an initial interval of 200 milliseconds,
- an interval multiplier of 1.5,
- a jitter factor of 0.2,
- a max interval of 30 seconds.

An optional xhttptrace.ClientTrace with a Retry hook can be added to the context passed to the http.Request object to instrument/inspect the retry logic.