### PR TITLE
refactor(xhttp): move request/response helper functions in their own file

### DIFF
--- a/xnet/xhttp/request.go
+++ b/xnet/xhttp/request.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package xhttp
+
+import "net/http"
+
+func isRequestIdempotent(req *http.Request) bool {
+	switch req.Method {
+	// idempotent methods: https://datatracker.ietf.org/doc/html/rfc9110#section-9.2.2
+	case http.MethodDelete, http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodPut, http.MethodTrace:
+		return true
+	default:
+		// Any request is retryable if either Idempotency-Key or X-Idempotency-Key request header is set.
+		return req.Header.Get(HeaderIdempotencyKey) != "" || req.Header.Get(HeaderXIdempotencyKey) != ""
+	}
+}
+
+func isRequestRewindable(req *http.Request) bool {
+	return req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+}

--- a/xnet/xhttp/response.go
+++ b/xnet/xhttp/response.go
@@ -1,0 +1,22 @@
+// Copyright 2023 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package xhttp
+
+import "net/http"
+
+func isResponseRetryable(resp *http.Response) bool {
+	switch resp.StatusCode {
+	// 4xx status codes
+	case http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests:
+		return true
+	// 413 is retryable if Retry-After header is set.
+	case http.StatusRequestEntityTooLarge:
+		return resp.Header.Get(HeaderRetryAfter) != ""
+	// 5xx status codes
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Moves request/response helper functions used in by the retry transport in their own file, respectively request.go and response.go.