### PR TITLE
fix(xhttp): HTTP retry transport parse time

### DIFF
--- a/xnet/xhttp/retrytransport.go
+++ b/xnet/xhttp/retrytransport.go
@@ -113,12 +113,12 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func computeWaitDuration(interval time.Duration, jitterFactor float64, headers http.Header) time.Duration {
 	if retryAfter := headers.Get(HeaderRetryAfter); retryAfter != "" {
-		if date, err := time.Parse(time.RFC1123, retryAfter); err == nil {
-			return time.Until(date)
-		}
-
 		if secs, err := strconv.Atoi(retryAfter); err == nil {
 			return time.Duration(secs) * time.Second
+		}
+
+		if date, err := http.ParseTime(retryAfter); err == nil {
+			return time.Until(date)
 		}
 	}
 

--- a/xnet/xhttp/retrytransport_test.go
+++ b/xnet/xhttp/retrytransport_test.go
@@ -45,7 +45,7 @@ func TestRetryTransport_RoundTrip(t *testing.T) {
 		StatusCode: http.StatusRequestEntityTooLarge,
 	}
 	resp429 := &http.Response{
-		Header:     http.Header{xhttp.HeaderRetryAfter: []string{time.Now().Add(50 * time.Millisecond).Format(time.RFC1123)}},
+		Header:     http.Header{xhttp.HeaderRetryAfter: []string{time.Now().Add(50 * time.Millisecond).Format(http.TimeFormat)}},
 		StatusCode: http.StatusTooManyRequests,
 	}
 	resp503 := &http.Response{StatusCode: http.StatusServiceUnavailable}


### PR DESCRIPTION
Use http.ParseTime to parse Retry-After header values that follow the HTTP-date format.