### PR TITLE
ci(tools): upgrade tooling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.22'
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55
+          version: v1.56
   # tests
   test:
     needs: lint
@@ -41,9 +41,9 @@ jobs:
       XGO_XERRORS_ENABLE_STACK_TRACE: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.golang }}
       - name: Run tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Semantic release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         with:
           branches: '[ "main" ]'
           extra_plugins: |
-            conventional-changelog-conventionalcommits@v5
-          semantic_version: v19
+            conventional-changelog-conventionalcommits@v7
+          semantic_version: v23
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/golang@0.4.0
         continue-on-error: true

--- a/xnet/port_test.go
+++ b/xnet/port_test.go
@@ -39,7 +39,7 @@ func TestFreePort(t *testing.T) {
 		{
 			name: "tcp network - failure",
 			options: []xnet.ListenConfigOption{
-				xnet.ListenConfigControl(func(network, address string, c syscall.RawConn) error {
+				xnet.ListenConfigControl(func(_, _ string, _ syscall.RawConn) error {
 					return errors.New("always error")
 				}),
 				xnet.ListenConfigKeepAlive(time.Second),
@@ -50,7 +50,7 @@ func TestFreePort(t *testing.T) {
 		{
 			name: "udp network - failure",
 			options: []xnet.ListenConfigOption{
-				xnet.ListenConfigControl(func(network, address string, c syscall.RawConn) error {
+				xnet.ListenConfigControl(func(_, _ string, _ syscall.RawConn) error {
 					return errors.New("always error")
 				}),
 				xnet.ListenConfigKeepAlive(time.Second),

--- a/xnet/xhttp/xhttptrace/trace_test.go
+++ b/xnet/xhttp/xhttptrace/trace_test.go
@@ -25,7 +25,7 @@ func TestContextClientTrace(t *testing.T) {
 		{
 			name: "specified trace",
 			trace: &xhttptrace.ClientTrace{
-				Retry: func(ri xhttptrace.RetryInfo) {},
+				Retry: func(_ xhttptrace.RetryInfo) {},
 			},
 		},
 	}

--- a/xsort/exist_test.go
+++ b/xsort/exist_test.go
@@ -26,13 +26,13 @@ func TestExist(t *testing.T) {
 		{
 			name:     "only lower values",
 			n:        1e9,
-			cmp:      func(i int) int { return -1 },
+			cmp:      func(_ int) int { return -1 },
 			expected: false,
 		},
 		{
 			name:     "only greater values",
 			n:        1e9,
-			cmp:      func(i int) int { return +1 },
+			cmp:      func(_ int) int { return +1 },
 			expected: false,
 		},
 		{


### PR DESCRIPTION
actions/checkout: v3 -> v4
actions/setup-go: v4 -> v5
golangci/golangci-lint-action: v3 -> v4
golangci-lint: v1.55 -> v1.56
cycjimmy/semantic-release-action: v3 -> v4
conventional-changelog-conventionalcommits: v5 -> v7
semantic release: v19 -> v23
