### PR TITLE
fix(xtime): ensure TimeMilli serializes with trailing zeros

### DIFF
--- a/xtime/format.go
+++ b/xtime/format.go
@@ -10,7 +10,7 @@ import (
 
 // These are predefined extra layouts to use in time.Format and time.Parse.
 const (
-	RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
+	RFC3339Milli = "2006-01-02T15:04:05.000Z07:00"
 )
 
 // ParseMilli parses a formatted string and returns the time value it represents as TimeMilli.

--- a/xtime/format_test.go
+++ b/xtime/format_test.go
@@ -190,6 +190,12 @@ func TestParseStampMilliInLocation(t *testing.T) {
 			expectedErr: true,
 		},
 		{
+			name:         "RFC3339Nano - no fractional second",
+			layout:       time.RFC3339Nano,
+			value:        "2016-07-10T21:12:00Z",
+			expectedTime: xtime.DateStampMilli(2016, time.July, 10, 21, 12, 0, 0, time.UTC),
+		},
+		{
 			name:         "RFC3339Milli - nil location",
 			layout:       xtime.RFC3339Milli,
 			value:        "2016-07-10T21:12:00.499Z",

--- a/xtime/time_test.go
+++ b/xtime/time_test.go
@@ -308,7 +308,7 @@ func TestTimeMilli_MarshalJSON(t *testing.T) {
 		{
 			name:          "zone info - no msec",
 			time:          xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
-			expectedBytes: []byte(`"2016-07-10T21:12:00+02:00"`),
+			expectedBytes: []byte(`"2016-07-10T21:12:00.000+02:00"`),
 			expectedErr:   nil,
 		},
 	}
@@ -351,7 +351,7 @@ func TestTimeMilli_MarshalText(t *testing.T) {
 		{
 			name:          "zone info - no msec",
 			time:          xtime.DateMilli(2016, time.July, 10, 21, 12, 0, 0, time.FixedZone("CET", 2*60*60)),
-			expectedBytes: []byte(`2016-07-10T21:12:00+02:00`),
+			expectedBytes: []byte(`2016-07-10T21:12:00.000+02:00`),
 			expectedErr:   nil,
 		},
 	}


### PR DESCRIPTION
TimeMilli type is meant to breach the gap that exists in terms of time serialization between languages like Javascript (millisecond precision) and Golang (nanosecond precision).

The JSON encoding would result in a millisecond-precision ISO date time with trailing zeros for fractional seconds, which is what this fix implements as well.