### PR TITLE
feat(xerrors): implement Join which deprecates Append

### DIFF
--- a/xerrors/example_test.go
+++ b/xerrors/example_test.go
@@ -25,11 +25,11 @@ func ExampleAppend() {
 	var errs error
 
 	if err := vetOperands(-1, -2); err != nil {
-		errs = xerrors.Append(errs, xerrors.Wrapf(err, "failed to vet operands %d and %d", 0, -2))
+		errs = xerrors.Append(errs, xerrors.Wrapf(err, "failed to vet operands %d and %d", -1, -2))
 	}
 
 	if err := vetOperands(0, -2); err != nil {
-		errs = xerrors.Append(errs, xerrors.Wrapf(err, "failed to vet operands %d and %d", 0, 0))
+		errs = xerrors.Append(errs, xerrors.Wrapf(err, "failed to vet operands %d and %d", 0, -2))
 	}
 
 	if errs != nil {
@@ -38,10 +38,10 @@ func ExampleAppend() {
 
 	// Output:
 	// 2 errors occurred:
-	//	* failed to vet operands 0 and -2: 2 errors occurred:
+	//	* failed to vet operands -1 and -2: 2 errors occurred:
 	// 		* left operand is negative
 	// 		* right operand is negative
-	// 	* failed to vet operands 0 and 0: 1 error occurred:
+	// 	* failed to vet operands 0 and -2: 1 error occurred:
 	// 		* right operand is negative
 }
 
@@ -56,6 +56,42 @@ func ExampleAs() {
 	}
 
 	// Output: Failed at path: non-existing
+}
+
+func ExampleJoin() {
+	xerrors.EnableStackTrace(true)
+	defer xerrors.EnableStackTrace(false)
+
+	vetOperands := func(a, b int) (errs error) {
+		if a < 0 {
+			errs = xerrors.Join(errs, xerrors.New("left operand is negative"))
+		}
+		if b < 0 {
+			errs = xerrors.Join(errs, xerrors.New("right operand is negative"))
+		}
+		return errs
+	}
+
+	var errs error
+
+	if err := vetOperands(-1, -2); err != nil {
+		errs = xerrors.Join(errs, xerrors.Wrapf(err, "failed to vet operands %d and %d", -1, -2))
+	}
+
+	if err := vetOperands(0, -2); err != nil {
+		errs = xerrors.Append(errs, xerrors.Wrapf(err, "failed to vet operands %d and %d", 0, -2))
+	}
+
+	if errs != nil {
+		fmt.Print(errs)
+	}
+
+	// Output:
+	// 2 errors occurred:
+	//	* failed to vet operands -1 and -2: 2 errors occurred:
+	// 		* left operand is negative
+	// 		* right operand is negative
+	// 	* failed to vet operands 0 and -2: right operand is negative
 }
 
 func ExampleIs() {

--- a/xerrors/join.go
+++ b/xerrors/join.go
@@ -1,0 +1,121 @@
+// Copyright 2024 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unsafe"
+)
+
+// Join returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if every value in errs is nil.
+// The error formats as the concatenation of the strings obtained
+// by calling the Error method of each element of errs, with a newline
+// between each string.
+//
+// A non-nil error returned by Join implements the Unwrap() []error method.
+//
+// It is the drop-in replacement for errors.Join.
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		if _, ok := err.(StackTracer); !ok {
+			err = &withStack{
+				error: err,
+				stack: callers(),
+			}
+		}
+		e.errs = append(e.errs, err)
+	}
+	return e
+}
+
+type joinError struct {
+	errs []error
+}
+
+// Error makes joinError implement the error interface.
+func (e *joinError) Error() string {
+	// Since Join returns nil if every value in errs is nil,
+	// e.errs cannot be empty.
+	if len(e.errs) == 1 {
+		return e.errs[0].Error()
+	}
+
+	b := []byte(strconv.Itoa(len(e.errs)) + " errors occurred:\n")
+	for _, err := range e.errs {
+		b = append(b, '\t', '*', ' ')
+
+		lines := strings.Split(strings.TrimSuffix(err.Error(), "\n"), "\n")
+		b = append(b, lines[0]...)
+		b = append(b, '\n')
+
+		for _, line := range lines[1:] {
+			b = append(b, '\t')
+			b = append(b, line...)
+			b = append(b, '\n')
+		}
+	}
+	return unsafe.String(&b[0], len(b))
+}
+
+// Format makes joinError implement the fmt.Formatter interface.
+func (e *joinError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			if len(e.errs) == 1 {
+				fmt.Fprint(s, e.errs[0].Error())
+				return
+			}
+
+			fmt.Fprint(s, strconv.Itoa(len(e.errs)), " errors occurred:\n")
+			for _, err := range e.errs {
+				lines := strings.Split(strings.TrimSuffix(fmt.Sprintf("%+v", err), "\n"), "\n")
+				fmt.Fprint(s, "\t* ", lines[0], "\n")
+				for _, line := range lines[1:] {
+					fmt.Fprint(s, "\t", line, "\n")
+				}
+			}
+			return
+		}
+		if s.Flag('#') {
+			fmt.Fprintf(s, "%T{errs:(%T)(%p)}", e, e.errs, &e.errs)
+			return
+		}
+		fallthrough
+	case 's':
+		fmt.Fprint(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	}
+}
+
+// StackTrace makes joinError implement the StackTracer interface.
+func (e *joinError) StackTrace() StackTrace {
+	return e.errs[0].(StackTracer).StackTrace()
+}
+
+// Unwrap makes joinError implement the errors.Unwrapper interface.
+func (e *joinError) Unwrap() []error {
+	return e.errs
+}

--- a/xerrors/join_test.go
+++ b/xerrors/join_test.go
@@ -1,0 +1,249 @@
+// Copyright 2024 Jérémy Lourenço. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors_test
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jlourenc/xgo/xerrors"
+)
+
+func TestJoin(t *testing.T) {
+	err0 := xerrors.New("err0")
+	err1 := xerrors.New("err1")
+
+	testCases := []struct {
+		name     string
+		errs     []error
+		expected []error
+	}{
+		{
+			name:     "join nothing",
+			errs:     nil,
+			expected: nil,
+		},
+		{
+			name:     "join nil error",
+			errs:     []error{nil},
+			expected: nil,
+		},
+		{
+			name:     "join nil errors",
+			errs:     []error{nil, nil},
+			expected: nil,
+		},
+		{
+			name:     "join error",
+			errs:     []error{err0},
+			expected: []error{err0},
+		},
+		{
+			name:     "join errors",
+			errs:     []error{err0, err1},
+			expected: []error{err0, err1},
+		},
+		{
+			name:     "join errors including nil",
+			errs:     []error{nil, err0, nil, err1},
+			expected: []error{err0, err1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := xerrors.Join(tc.errs...)
+
+			if tc.expected == nil && got != nil {
+				t.Errorf("expected no error, got %s", got)
+				return
+			}
+
+			if tc.expected != nil && got == nil {
+				t.Errorf("expected %q, got no error", tc.expected)
+				return
+			}
+
+			if got != nil {
+				errs := got.(interface{ Unwrap() []error }).Unwrap()
+				if !slices.Equal(errs, tc.expected) {
+					t.Errorf("expected %v, got %v", tc.expected, got)
+				}
+				if len(errs) != cap(errs) {
+					t.Errorf("with %v len!=cap, len=%d, cap=%d", tc.errs, len(errs), cap(errs))
+				}
+			}
+		})
+	}
+}
+
+func TestJoinError_Error(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "single error",
+			err:      xerrors.Join(xerrors.New("err0")),
+			expected: "err0",
+		},
+		{
+			name: "multiple errors",
+			err: xerrors.Join(
+				xerrors.New("err0"),
+				xerrors.Join(xerrors.New("err1.0"), xerrors.New("err1.1")),
+				xerrors.Join(xerrors.New("err2")),
+			),
+			expected: "3 errors occurred:\n\t* err0\n\t* 2 errors occurred:\n\t\t* err1.0\n\t\t* err1.1\n\t* err2\n",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.err.Error()
+
+			if tc.expected != got {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestJoinError_Format(t *testing.T) {
+	xerrors.EnableStackTrace(false)
+
+	testCases := []struct {
+		name     string
+		err      error
+		format   string
+		expected string
+	}{
+		{
+			name: "default",
+			err: xerrors.Join(
+				xerrors.New("error message 0"),
+				xerrors.Wrap(xerrors.Join(xerrors.New("error message 1"), xerrors.New("error message 2")), "wrapped"),
+				xerrors.Join(xerrors.New("error message 3")),
+			),
+			format: "%v",
+			expected: strings.Join([]string{
+				`3 errors occurred:\n\t`,
+				`\* error message 0\n\t`,
+				`\* wrapped: 2 errors occurred:\n\t\t\* error message 1\n\t\t\* error message 2\n\t`,
+				`\* error message 3\n`,
+			}, ""),
+		},
+		{
+			name: "default plus extra with stack trace disabled",
+			err: xerrors.Join(
+				xerrors.New("error message 0"),
+				xerrors.Wrap(xerrors.Join(xerrors.New("error message 1"), xerrors.New("error message 2")), "wrapped"),
+				xerrors.Join(xerrors.New("error message 3")),
+			),
+			format: "%+v",
+			expected: strings.Join([]string{
+				`3 errors occurred:\n\t`,
+				`\* error message 0\n\t`,
+				`\* wrapped: 2 errors occurred:\n\t\t\* error message 1\n\t\t\* error message 2\n\t`,
+				`\* error message 3\n`,
+			}, ""),
+		},
+		{
+			name: "Go-syntax representation of the value with stack trace disabled",
+			err: xerrors.Join(
+				xerrors.New("error message 0"),
+				xerrors.Wrap(xerrors.Join(xerrors.New("error message 1"), xerrors.New("error message 2")), "wrapped"),
+				xerrors.Join(xerrors.New("error message 3")),
+			),
+			format:   "%#v",
+			expected: `\*xerrors\.joinError\{errs:\(\[\]error\)\(0x[a-f0-9]+\)\}`,
+		},
+		{
+			name: "string",
+			err: xerrors.Join(
+				xerrors.New("error message 0"),
+				xerrors.Wrap(xerrors.Join(xerrors.New("error message 1"), xerrors.New("error message 2")), "wrapped"),
+				xerrors.Join(xerrors.New("error message 3")),
+			),
+			format: "%s",
+			expected: strings.Join([]string{
+				`3 errors occurred:\n\t`,
+				`\* error message 0\n\t`,
+				`\* wrapped: 2 errors occurred:\n\t\t\* error message 1\n\t\t\* error message 2\n\t`,
+				`\* error message 3\n`,
+			}, ""),
+		},
+		{
+			name: "double-quote string",
+			err: xerrors.Join(
+				xerrors.New("error message 0"),
+				xerrors.Wrap(xerrors.Join(xerrors.New("error message 1"), xerrors.New("error message 2")), "wrapped"),
+				xerrors.Join(xerrors.New("error message 3")),
+			),
+			format: "%q",
+			expected: strings.Join([]string{
+				`\"3 errors occurred:\\n\\t`,
+				`\* error message 0\\n\\t`,
+				`\* wrapped: 2 errors occurred:\\n\\t\\t\* error message 1\\n\\t\\t\* error message 2\\n\\t`,
+				`\* error message 3\\n\"`,
+			}, ""),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fmt.Sprintf(tc.format, tc.err)
+
+			re, err := regexp.Compile(tc.expected)
+			if err != nil {
+				t.Fatalf("invalid regex: %s", tc.expected)
+			}
+			if !re.MatchString(got) {
+				t.Errorf("expected pattern %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestJoinError_StackTrace(t *testing.T) {
+	testCases := []struct {
+		name             string
+		errs             []error
+		enableStackTrace bool
+		expectedSize     int
+	}{
+		{
+			name:         "stack error",
+			errs:         []error{&stackError{}, &unstackError{}},
+			expectedSize: 4,
+		},
+		{
+			name:         "unstack error with stack trace disabled",
+			errs:         []error{&unstackError{}, &stackError{}},
+			expectedSize: 0,
+		},
+		{
+			name:             "unstack error with stack trace enabled",
+			errs:             []error{&unstackError{}, &stackError{}},
+			enableStackTrace: true,
+			expectedSize:     3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			xerrors.EnableStackTrace(tc.enableStackTrace)
+			defer xerrors.EnableStackTrace(false)
+
+			got := xerrors.Join(tc.errs...).(interface{ StackTrace() xerrors.StackTrace }).StackTrace()
+
+			if len(got) != tc.expectedSize {
+				t.Errorf("expected stack trace of size %d, got %v", tc.expectedSize, got)
+			}
+		})
+	}
+}

--- a/xerrors/slice.go
+++ b/xerrors/slice.go
@@ -13,6 +13,8 @@ import (
 // Append is a helper function that appends errors into a single error to group
 // multiple errors. Any nil error within errs is ignored. If err is not a grouped
 // error then it will be turned into one.
+//
+// Deprecated: use xerrors.Join instead.
 func Append(err error, errs ...error) error {
 	sliceErr, ok := err.(*withSlice)
 	if !ok {
@@ -61,7 +63,7 @@ func (e *withSlice) Error() string {
 	sb.WriteString(" occurred:\n")
 
 	for _, err := range e.errs {
-		lines := strings.Split(strings.Trim(err.Error(), "\n"), "\n")
+		lines := strings.Split(strings.TrimSuffix(err.Error(), "\n"), "\n")
 		sb.WriteString("\t* ")
 		sb.WriteString(lines[0])
 		sb.WriteString("\n")
@@ -89,14 +91,10 @@ func (e *withSlice) Format(s fmt.State, verb rune) {
 			fmt.Fprint(s, " occurred:\n")
 
 			for _, err := range e.errs {
-				lines := strings.Split(strings.Trim(fmt.Sprintf("%+v", err), "\n"), "\n")
-				fmt.Fprint(s, "\t* ")
-				fmt.Fprint(s, lines[0])
-				fmt.Fprint(s, "\n")
+				lines := strings.Split(strings.TrimSuffix(fmt.Sprintf("%+v", err), "\n"), "\n")
+				fmt.Fprint(s, "\t* ", lines[0], "\n")
 				for _, line := range lines[1:] {
-					fmt.Fprint(s, "\t")
-					fmt.Fprint(s, line)
-					fmt.Fprint(s, "\n")
+					fmt.Fprint(s, "\t", line, "\n")
 				}
 			}
 			return


### PR DESCRIPTION
Following introduction of errors.Join in 1.20, deprecate xerrors.Append and replace by it by xerrors.Join.

xerrors.Join is reimplemented but mostly aligned with errors.Join to appropriately take stack traces when necessary. Function can be used as a drop-in replacement for errors.Join.

String serialization of joined errors differ from the Go SDK to keep indentation so that a tree of joined errors can be better appreciated, as opposed to the flat structure provided by errors.Join.